### PR TITLE
Ensure node.Close and node.RemoveWorker properly stop local jobs

### DIFF
--- a/pool/README.md
+++ b/pool/README.md
@@ -20,7 +20,6 @@ Pulse uses the [Jump Consistent Hash](https://arxiv.org/abs/1406.2294) algorithm
 to assign jobs to workers which provides a good balance between load balancing
 and worker assignment stability.
 
-
 ```mermaid
 %%{init: {'themeVariables': { 'edgeLabelBackground': '#7A7A7A'}}}%%
 flowchart LR
@@ -216,12 +215,12 @@ flowchart TD
     end
     pr --1. DispatchJob--> no
     no --2. Add Job--> js
-    js -.3. Job.-> ps
+    js --3. Job--> ps
     ps --4. Add Job--> ws
-    ws -.5. Job.-> r
+    ws --5. Job--> r
     r --6. Start Job--> u
     r --7. Add Ack--> rs
-    rs -.7. Ack.-> nr
+    rs --7. Ack--> nr
     nr --8. Ack Add Job Event--> js
     
     classDef userCode fill:#9A6D1F, stroke:#D9B871, stroke-width:2px, color:#FFF2CC;

--- a/pool/node.go
+++ b/pool/node.go
@@ -526,7 +526,7 @@ func (node *Node) ackWorkerEvent(ctx context.Context, ev *streaming.Event) {
 }
 
 // returnDispatchStatus returns the start job result to the caller.
-func (node *Node) returnDispatchStatus(ctx context.Context, ev *streaming.Event) {
+func (node *Node) returnDispatchStatus(_ context.Context, ev *streaming.Event) {
 	node.lock.Lock()
 	defer node.lock.Unlock()
 
@@ -738,7 +738,7 @@ func (node *Node) deleteWorker(ctx context.Context, id string) error {
 
 // workerStream retrieves the stream for a worker. It caches the result in the
 // workerStreams map. Caller is responsible for locking.
-func (node *Node) workerStream(ctx context.Context, id string) (*streaming.Stream, error) {
+func (node *Node) workerStream(_ context.Context, id string) (*streaming.Stream, error) {
 	stream, ok := node.workerStreams[id]
 	if !ok {
 		s, err := streaming.NewStream(workerStreamName(id), node.rdb, soptions.WithStreamLogger(node.logger))

--- a/pool/scheduler.go
+++ b/pool/scheduler.go
@@ -170,7 +170,7 @@ func (sched *scheduler) stopJobs(ctx context.Context, plan *JobPlan) error {
 }
 
 // handleStop handles the scheduler stop signal.
-func (sched *scheduler) handleStop(ctx context.Context) {
+func (sched *scheduler) handleStop(_ context.Context) {
 	ch := sched.jobMap.Subscribe()
 	for ev := range ch {
 		if ev == rmap.EventReset {

--- a/scripts/test
+++ b/scripts/test
@@ -9,9 +9,15 @@ pushd ${GIT_ROOT}
 
 staticcheck ./...
 
+# If --force is passed, add --count=1 to the go test command
+if [[ "$1" == "--force" ]]; then
+    shift
+    OPTIONS="--count=1"
+fi
+
 # Run tests one package at a time to avoid Redis race conditions
-go test -race goa.design/pulse/rmap/... 
-go test -race goa.design/pulse/streaming/...
-go test -race goa.design/pulse/pool/...
+go test -race goa.design/pulse/rmap/... $OPTIONS
+go test -race goa.design/pulse/streaming/... $OPTIONS
+go test -race goa.design/pulse/pool/... $OPTIONS
 
 popd


### PR DESCRIPTION
Before they get requeued.