### PR TITLE
Fix a few issues

### DIFF
--- a/examples/streaming/multi-sinks/main.go
+++ b/examples/streaming/multi-sinks/main.go
@@ -54,7 +54,7 @@ func main() {
 	}
 
 	// Don't forget to close the sink when done
-	defer sink1.Close()
+	defer sink1.Close(ctx)
 
 	// Read and acknowlege event
 	ev := <-sink1.Subscribe()
@@ -70,7 +70,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	defer sink2.Close()
+	defer sink2.Close(ctx)
 
 	// Read second event
 	ev = <-sink2.Subscribe()

--- a/examples/streaming/multi-streams/main.go
+++ b/examples/streaming/multi-streams/main.go
@@ -40,7 +40,7 @@ func main() {
 	}
 
 	// Don't forget to close the sink when done
-	defer sink.Close()
+	defer sink.Close(ctx)
 
 	// Subscribe to events
 	c := sink.Subscribe()

--- a/examples/streaming/pub-sub/main.go
+++ b/examples/streaming/pub-sub/main.go
@@ -56,7 +56,7 @@ func main() {
 	}
 
 	// Don't forget to close the sink when done
-	defer sink.Close()
+	defer sink.Close(ctx)
 
 	// Read both events
 	c := sink.Subscribe()

--- a/examples/streaming/single-sink/main.go
+++ b/examples/streaming/single-sink/main.go
@@ -45,7 +45,7 @@ func main() {
 	}
 
 	// Don't forget to close the sink when done
-	defer sink.Close()
+	defer sink.Close(ctx)
 
 	// Consume event
 	ev := <-sink.Subscribe()

--- a/pool/testing.go
+++ b/pool/testing.go
@@ -26,7 +26,7 @@ type mockHandlerWithoutNotify struct {
 const (
 	testWorkerShutdownTTL    = 100 * time.Millisecond
 	testJobSinkBlockDuration = 100 * time.Millisecond
-	testWorkerTTL            = 100 * time.Millisecond
+	testWorkerTTL            = 150 * time.Millisecond
 	testAckGracePeriod       = 50 * time.Millisecond
 )
 

--- a/pool/worker_test.go
+++ b/pool/worker_test.go
@@ -33,7 +33,7 @@ func TestWorkerRequeueJobs(t *testing.T) {
 
 	// Emulate the worker failing by preventing it from refreshing its keepalive
 	// This means we can't cleanup cleanly, hence "false" in CleanupRedis
-	worker.stopAndWait(ctx)
+	worker.stop(ctx)
 
 	// Create a new worker to pick up the requeued job
 	newWorker := newTestWorker(t, ctx, node)
@@ -73,7 +73,7 @@ func TestStaleWorkerCleanupInNode(t *testing.T) {
 		staleWorkers[i] = newTestWorker(t, ctx, node)
 		staleWorkers[i].stop(ctx)
 		// Set the last seen time to a past time
-		_, err := node.keepAliveMap.Set(ctx, staleWorkers[i].ID, strconv.FormatInt(time.Now().Add(-2*node.workerTTL).UnixNano(), 10))
+		_, err := node.workerKeepAliveMap.Set(ctx, staleWorkers[i].ID, strconv.FormatInt(time.Now().Add(-2*node.workerTTL).UnixNano(), 10))
 		assert.NoError(t, err)
 	}
 
@@ -108,7 +108,7 @@ func TestStaleWorkerCleanupAcrossNodes(t *testing.T) {
 		staleWorkers[i] = newTestWorker(t, ctx, node2)
 		staleWorkers[i].stop(ctx)
 		// Set the last seen time to a past time
-		_, err := node2.keepAliveMap.Set(ctx, staleWorkers[i].ID, strconv.FormatInt(time.Now().Add(-2*node2.workerTTL).UnixNano(), 10))
+		_, err := node2.workerKeepAliveMap.Set(ctx, staleWorkers[i].ID, strconv.FormatInt(time.Now().Add(-2*node2.workerTTL).UnixNano(), 10))
 		assert.NoError(t, err)
 	}
 

--- a/rmap/map_test.go
+++ b/rmap/map_test.go
@@ -160,7 +160,9 @@ func TestMapLocal(t *testing.T) {
 	old, err = m.Delete(ctx, key)
 	assert.Error(t, err)
 	assert.Equal(t, "", old)
-	assert.Error(t, m.Reset(ctx))
+
+	// Reset should work after the map is closed
+	assert.NoError(t, m.Reset(ctx))
 
 	// Cleanup
 	m, err = Join(ctx, "test", rdb)
@@ -430,7 +432,7 @@ func TestLogs(t *testing.T) {
 	assert.Contains(t, buf.String(), `key=foo val=bar`)
 	assert.Contains(t, buf.String(), `msg=deleted key=foo`)
 	assert.Contains(t, buf.String(), `reset`)
-	assert.Contains(t, buf.String(), `stopped`)
+	assert.Contains(t, buf.String(), `closed`)
 }
 
 func TestJoinErrors(t *testing.T) {

--- a/streaming/reader.go
+++ b/streaming/reader.go
@@ -272,6 +272,7 @@ func (r *Reader) cleanup() {
 	for _, c := range r.chans {
 		close(c)
 	}
+	r.chans = nil
 	r.wait.Done()
 }
 

--- a/streaming/testing.go
+++ b/streaming/testing.go
@@ -64,7 +64,7 @@ func readOneReaderEvent(t *testing.T, c <-chan *Event) *Event {
 func cleanupSink(t *testing.T, ctx context.Context, s *Stream, sink *Sink) {
 	t.Helper()
 	if sink != nil {
-		sink.Close()
+		sink.Close(ctx)
 		assert.Eventually(t, func() bool { return sink.IsClosed() }, max, delay)
 	}
 	if s != nil {

--- a/testing/redis.go
+++ b/testing/redis.go
@@ -3,6 +3,7 @@ package testing
 import (
 	"context"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -40,8 +41,12 @@ func CleanupRedis(t *testing.T, rdb *redis.Client, checkClean bool, testName str
 		require.NoError(t, err)
 		var filtered []string
 		for _, k := range keys {
-			// Sinks content gets reused, so ignore it
 			if strings.HasSuffix(k, ":sinks:content") {
+				// Sinks content is cleaned up asynchronously, so ignore it
+				continue
+			}
+			if regexp.MustCompile(`^pulse:stream:[^:]+:node:.*`).MatchString(k) {
+				// Node streams are cleaned up asynchronously, so ignore them
 				continue
 			}
 			if strings.Contains(k, testName) {


### PR DESCRIPTION
* Make sure that adding a dispatch return event to a node stream creates the stream if needed. This could cause jobs that are added right on startup to fail to be dispatched.
* Fix potential panic in cleanup goroutine when the pending jobs map contains nil values
* Make sure to close all maps when closing the node.
* Properly log event information when discarding stale ack events.
* More consistent logging