### PR TITLE
pool: Enhance worker lifecycle management and job reliability

### DIFF
--- a/pool/node.go
+++ b/pool/node.go
@@ -727,7 +727,7 @@ func (node *Node) ackWorkerEvent(ev *streaming.Event) {
 			return
 		}
 		ack.EventID = pending.ID
-		if _, err := stream.Add(ctx, evDispatchReturn, marshalAck(ack)); err != nil {
+		if _, err := stream.Add(ctx, evDispatchReturn, marshalAck(ack), options.WithOnlyIfStreamExists()); err != nil {
 			node.logger.Error(fmt.Errorf("ackWorkerEvent: failed to dispatch return to stream %q: %w", nodeStreamName(node.PoolName, nodeID), err))
 		}
 	}

--- a/pool/node.go
+++ b/pool/node.go
@@ -832,9 +832,7 @@ func (node *Node) requeueJob(workerID string, job *Job) (chan error, error) {
 		node.logger.Debug("requeueJob: job already removed from jobs map", "key", job.Key, "worker", workerID)
 		return nil, nil
 	}
-	node.logger.Info("requeuing job", "key", job.Key, "worker", workerID)
 	job.NodeID = node.ID
-
 	eventID, err := node.poolStream.Add(ctx, evStartJob, marshalJob(job))
 	if err != nil {
 		if _, err := node.jobMap.AppendValues(ctx, workerID, job.Key); err != nil {
@@ -842,6 +840,7 @@ func (node *Node) requeueJob(workerID string, job *Job) (chan error, error) {
 		}
 		return nil, fmt.Errorf("requeueJob: failed to add job %q to stream %q: %w", job.Key, node.poolStream.Name, err)
 	}
+	node.logger.Info("requeued job", "key", job.Key, "worker", workerID, "event", eventID)
 	cherr := make(chan error, 1)
 	node.pendingJobChannels.Store(eventID, cherr)
 	return cherr, nil

--- a/pool/scheduler.go
+++ b/pool/scheduler.go
@@ -99,8 +99,9 @@ func (node *Node) Schedule(ctx context.Context, producer JobProducer, interval t
 	if err := sched.stopJobs(ctx, plan); err != nil {
 		return fmt.Errorf("failed to stop jobs: %w", err)
 	}
-	pulse.Go(ctx, func() { sched.scheduleJobs(ctx, ticker, producer) })
-	pulse.Go(ctx, func() { sched.handleStop(ctx) })
+
+	pulse.Go(sched.logger, func() { sched.scheduleJobs(ctx, ticker, producer) })
+	pulse.Go(sched.logger, func() { sched.handleStop() })
 	return nil
 }
 
@@ -175,7 +176,7 @@ func (sched *scheduler) stopJobs(ctx context.Context, plan *JobPlan) error {
 }
 
 // handleStop handles the scheduler stop signal.
-func (sched *scheduler) handleStop(_ context.Context) {
+func (sched *scheduler) handleStop() {
 	ch := sched.jobMap.Subscribe()
 	for ev := range ch {
 		if ev == rmap.EventReset {

--- a/pool/ticker.go
+++ b/pool/ticker.go
@@ -67,7 +67,7 @@ func (node *Node) NewTicker(ctx context.Context, name string, d time.Duration, o
 	}
 	t.initTimer()
 	t.wg.Add(1)
-	pulse.Go(ctx, func() { t.handleEvents() })
+	pulse.Go(logger, func() { t.handleEvents() })
 	return t, nil
 }
 

--- a/pool/worker.go
+++ b/pool/worker.go
@@ -213,6 +213,7 @@ func (w *Worker) handleEvents(ctx context.Context, c <-chan *streaming.Event) {
 			}
 			w.ackPoolEvent(ctx, nodeID, ev.ID, nil)
 		case <-w.done:
+			w.logger.Debug("handleEvents: done")
 			return
 		}
 	}
@@ -337,6 +338,7 @@ func (w *Worker) keepAlive(ctx context.Context) {
 				w.logger.Error(fmt.Errorf("failed to update worker keep-alive: %w", err))
 			}
 		case <-w.done:
+			w.logger.Debug("keepAlive: done")
 			return
 		}
 	}

--- a/pool/worker.go
+++ b/pool/worker.go
@@ -372,7 +372,7 @@ func (w *Worker) rebalance(ctx context.Context, activeWorkers []string) {
 		delete(rebalanced, key)
 		cherrs[key] = cherr
 	}
-	pulse.Go(w.logger, func() { w.node.processRequeuedJobs(ctx, w.ID, cherrs, false, 0) })
+	pulse.Go(w.logger, func() { w.node.processRequeuedJobs(ctx, w.ID, cherrs, false) })
 }
 
 // requeueJobs requeues the jobs handled by the worker.

--- a/pool/worker.go
+++ b/pool/worker.go
@@ -309,7 +309,7 @@ func (w *Worker) ackPoolEvent(ctx context.Context, nodeID, eventID string, acker
 		msg = ackerr.Error()
 	}
 	ack := &ack{EventID: eventID, Error: msg}
-	if _, err := stream.Add(ctx, evAck, marshalEnvelope(w.ID, marshalAck(ack))); err != nil {
+	if _, err := stream.Add(ctx, evAck, marshalEnvelope(w.ID, marshalAck(ack)), soptions.WithOnlyIfStreamExists()); err != nil {
 		w.logger.Error(fmt.Errorf("failed to ack event %q from node %q: %w", eventID, nodeID, err))
 	}
 }

--- a/pool/worker.go
+++ b/pool/worker.go
@@ -369,7 +369,7 @@ func (w *Worker) rebalance(ctx context.Context, activeWorkers []string) {
 		delete(rebalanced, key)
 		cherrs[key] = cherr
 	}
-	pulse.Go(ctx, func() { w.node.processRequeuedJobs(ctx, w.ID, cherrs, false) })
+	pulse.Go(ctx, func() { w.node.processRequeuedJobs(ctx, w.ID, cherrs, false, 0) })
 }
 
 // requeueJobs requeues the jobs handled by the worker.

--- a/pulse/goroutine.go
+++ b/pulse/goroutine.go
@@ -1,11 +1,8 @@
 package pulse
 
 import (
-	"context"
 	"fmt"
 	"runtime/debug"
-
-	"goa.design/clue/log"
 )
 
 // Go runs the given function in a separate goroutine and recovers from any panic,
@@ -16,14 +13,14 @@ import (
 //	Go(ctx, func() {
 //	    // Your code here
 //	})
-func Go(ctx context.Context, f func()) {
-	go func() {
-		defer func(ctx context.Context) {
+func Go(logger Logger, f func()) {
+	go func(logger Logger) {
+		defer func() {
 			if r := recover(); r != nil {
 				panicErr := fmt.Errorf("Panic recovered: %v\n%s", r, debug.Stack())
-				log.Error(ctx, panicErr)
+				logger.Error(panicErr)
 			}
-		}(ctx)
+		}()
 		f()
-	}()
+	}(logger)
 }

--- a/pulse/goroutine_test.go
+++ b/pulse/goroutine_test.go
@@ -14,12 +14,11 @@ import (
 
 func TestGo(t *testing.T) {
 	t.Run("executes function without panic", func(t *testing.T) {
-		ctx := context.Background()
 		var wg sync.WaitGroup
 		wg.Add(1)
 		executed := false
 
-		Go(ctx, func() {
+		Go(NoopLogger(), func() {
 			defer wg.Done()
 			executed = true
 		})
@@ -35,8 +34,9 @@ func TestGo(t *testing.T) {
 
 		var buf strings.Builder
 		ctx = log.Context(ctx, log.WithOutput(&buf))
+		logger := ClueLogger(ctx)
 
-		Go(ctx, func() {
+		Go(logger, func() {
 			defer wg.Done()
 			panic("test panic")
 		})
@@ -58,8 +58,9 @@ func TestGo(t *testing.T) {
 
 		var buf strings.Builder
 		ctx = log.Context(ctx, log.WithOutput(&buf))
+		logger := ClueLogger(ctx)
 
-		Go(ctx, func() {
+		Go(logger, func() {
 			defer wg.Done()
 			panic(errors.New("custom error"))
 		})

--- a/rmap/map.go
+++ b/rmap/map.go
@@ -25,7 +25,6 @@ type (
 		hashkey              string                // Redis hash key
 		msgch                <-chan *redis.Message // channel to receive map updates
 		chans                []chan EventKind      // channels to send notifications
-		ichan                chan setNotification  // internal channel to send set notifications
 		done                 chan struct{}         // channel to signal shutdown
 		wait                 sync.WaitGroup        // wait for read goroutine to exit
 		logger               pulse.Logger          // logger
@@ -34,10 +33,10 @@ type (
 		setScript            *redis.Script
 		testAndSetScript     *redis.Script
 		setIfNotExistsScript *redis.Script
+		incrScript           *redis.Script
 		appendScript         *redis.Script
 		appendUniqueScript   *redis.Script
 		removeScript         *redis.Script
-		incrScript           *redis.Script
 		delScript            *redis.Script
 		testAndDelScript     *redis.Script
 		testAndResetScript   *redis.Script
@@ -46,7 +45,10 @@ type (
 		lock    sync.RWMutex
 		content map[string]string
 		closing bool // true if Close was called
-		closed  bool // true if Close returned
+		closed  bool // true if Close returned - used by tests
+
+		wlock   sync.Mutex
+		waiters sync.Map // map of key to []*setWaiter
 	}
 
 	// EventKind is the type of map event.
@@ -56,6 +58,15 @@ type (
 	setNotification struct {
 		key   string
 		value string
+	}
+
+	// setWaiter represents a waiting SetAndWait operation
+	setWaiter struct {
+		ch     chan setNotification
+		key    string
+		value  string
+		ctx    context.Context // context for cancellation
+		cancel func()          // cleanup function
 	}
 )
 
@@ -91,7 +102,6 @@ func Join(ctx context.Context, name string, rdb *redis.Client, opts ...MapOption
 		Name:                 name,
 		chankey:              fmt.Sprintf("map:%s:updates", name),
 		hashkey:              fmt.Sprintf("map:%s:content", name),
-		ichan:                make(chan setNotification, 100),
 		done:                 make(chan struct{}),
 		logger:               o.Logger.WithPrefix("map", name),
 		rdb:                  rdb,
@@ -224,26 +234,86 @@ func (sm *Map) Set(ctx context.Context, key, value string) (string, error) {
 	return prev.(string), nil
 }
 
-// SetAndWait is a convenience method that calls Set and then waits for the
-// update to be applied and the notification to be sent.
+// SetAndWait is a convenience method that calls Set and waits for the update to be
+// applied and the notification to be sent. Multiple concurrent calls with the same
+// key and value are allowed - each call will receive its own notification when the
+// update is applied.
+//
+// The method will return an error if:
+// - The key is empty
+// - The key contains an equal sign
+// - The context is cancelled
+// - The map is stopped
+// - There's an issue with the Redis operation
 func (sm *Map) SetAndWait(ctx context.Context, key, value string) (string, error) {
+	notifyCh := make(chan setNotification, 1)
+
+	// Create cancellable context for cleanup
+	waitCtx, cancel := context.WithCancel(ctx)
+	waiter := &setWaiter{
+		ch:     notifyCh,
+		key:    key,
+		value:  value,
+		ctx:    waitCtx,
+		cancel: cancel,
+	}
+
+	// First mark the channel as closing before removing from waiters
+	defer func() {
+		// Cancel first to prevent new sends
+		cancel()
+
+		// Remove waiter under lock
+		sm.wlock.Lock()
+		if v, ok := sm.waiters.Load(key); ok {
+			waiters := v.([]*setWaiter)
+			newWaiters := make([]*setWaiter, 0, len(waiters))
+			for _, w := range waiters {
+				if w != waiter {
+					newWaiters = append(newWaiters, w)
+				}
+			}
+			if len(newWaiters) > 0 {
+				sm.waiters.Store(key, newWaiters)
+			} else {
+				sm.waiters.Delete(key)
+			}
+		}
+		sm.wlock.Unlock()
+
+		// Now safe to close channel as no more sends will occur
+		close(notifyCh)
+	}()
+
+	// Prepare new waiters list under lock
+	sm.wlock.Lock()
+	if v, ok := sm.waiters.Load(key); ok {
+		waiters := v.([]*setWaiter)
+		newWaiters := append(append([]*setWaiter(nil), waiters...), waiter) // Note: need to copy to avoid data race
+		sm.waiters.Store(key, newWaiters)
+	} else {
+		sm.waiters.Store(key, []*setWaiter{waiter})
+	}
+	sm.wlock.Unlock()
+
+	// Call Set - if it fails, the deferred cleanup will remove our waiter
 	prev, err := sm.Set(ctx, key, value)
 	if err != nil {
 		return "", err
 	}
-	// Wait for the update to be applied.
-	for {
-		select {
-		case <-ctx.Done():
-			return "", ctx.Err()
-		case ev, ok := <-sm.ichan:
-			if !ok {
-				return "", fmt.Errorf("pulse map: %s is stopped", sm.Name)
-			}
-			if ev.key == key && ev.value == value {
-				return prev, nil
-			}
+
+	// Wait for notification or context cancellation
+	select {
+	case <-ctx.Done():
+		return "", ctx.Err()
+	case <-sm.done:
+		return "", fmt.Errorf("pulse map: %s is stopped", sm.Name)
+	case ev := <-notifyCh:
+		if ev.key == key && ev.value == value {
+			return prev, nil
 		}
+		// This shouldn't happen as we only send matching notifications
+		return "", fmt.Errorf("pulse map: received unexpected notification key=%s value=%s", ev.key, ev.value)
 	}
 }
 
@@ -467,9 +537,21 @@ func (sm *Map) Close() {
 	}
 	sm.closing = true
 	sm.lock.Unlock()
+
+	// Signal run() to stop and wait for it to complete
 	close(sm.done)
 	sm.wait.Wait()
-	close(sm.ichan)
+
+	// Clean up all waiters
+	sm.wlock.Lock()
+	sm.waiters.Range(func(key, value interface{}) bool {
+		waiters := value.([]*setWaiter)
+		for _, w := range waiters {
+			w.cancel()
+		}
+		return true
+	})
+	sm.wlock.Unlock()
 	sm.lock.Lock()
 	sm.closed = true
 	sm.lock.Unlock()
@@ -538,6 +620,7 @@ func (sm *Map) run() {
 			op, data := parts[0], []byte(parts[1])
 			sm.lock.Lock()
 			kind := EventChange
+			var notification *setNotification
 			switch op {
 			case "reset":
 				sm.content = make(map[string]string)
@@ -567,9 +650,10 @@ func (sm *Map) run() {
 					continue
 				}
 				sm.content[key] = val
-				sm.ichan <- setNotification{key: key, value: val}
+				notification = &setNotification{key: key, value: val}
 				sm.logger.Debug("set", "key", key, "val", val)
 			}
+
 			for _, c := range sm.chans {
 				select {
 				case c <- kind:
@@ -577,6 +661,31 @@ func (sm *Map) run() {
 				}
 			}
 			sm.lock.Unlock()
+
+			// For set operations, notify waiters after releasing lock
+			if notification != nil {
+				// Load waiters for this key
+				if w, ok := sm.waiters.Load(notification.key); ok {
+					// Take lock only while reading waiters list
+					sm.wlock.Lock()
+					waiters := w.([]*setWaiter)
+					sm.wlock.Unlock()
+
+					// Notify matching waiters - no lock needed as each waiter has its own channel
+					for _, waiter := range waiters {
+						if waiter.key == notification.key && waiter.value == notification.value {
+							select {
+							case waiter.ch <- *notification:
+							case <-sm.done:
+								return
+							case <-waiter.ctx.Done():
+								// Waiter was cancelled or timed out
+								continue
+							}
+						}
+					}
+				}
+			}
 
 		case <-sm.done:
 			sm.logger.Info("closed")

--- a/rmap/map.go
+++ b/rmap/map.go
@@ -11,9 +11,8 @@ import (
 	"sync"
 	"time"
 
-	"goa.design/pulse/pulse"
-
 	"github.com/redis/go-redis/v9"
+	"goa.design/pulse/pulse"
 )
 
 type (
@@ -115,7 +114,7 @@ func Join(ctx context.Context, name string, rdb *redis.Client, opts ...MapOption
 
 	// read updates
 	sm.wait.Add(1)
-	pulse.Go(ctx, sm.run)
+	pulse.Go(sm.logger, sm.run)
 
 	sm.logger.Info("joined")
 	return sm, nil

--- a/streaming/reader.go
+++ b/streaming/reader.go
@@ -112,7 +112,7 @@ func newReader(ctx context.Context, stream *Stream, opts ...options.Reader) (*Re
 	}
 
 	reader.wait.Add(1)
-	pulse.Go(ctx, reader.read)
+	pulse.Go(reader.logger, reader.read)
 
 	return reader, nil
 }

--- a/streaming/sink.go
+++ b/streaming/sink.go
@@ -60,7 +60,7 @@ type (
 		// streams are the streams the sink consumes events from.
 		streams []*Stream
 		// streamCursors is the stream cursors used to read events in
-		// the form [stream1, ">", stream2, ">", ..."]
+		// the form [stream1, ">", stream2, ">", ...]
 		streamCursors []string
 		// blockDuration is the XREADGROUP timeout.
 		blockDuration time.Duration
@@ -156,6 +156,12 @@ func newSink(ctx context.Context, name string, stream *Stream, opts ...options.S
 		logger:                logger,
 		rdb:                   stream.rdb,
 	}
+
+	// Clean up any existing stale consumers before creating our own
+	if err := sink.deleteStreamStaleConsumers(ctx, stream); err != nil {
+		sink.logger.Error(fmt.Errorf("failed to cleanup stale consumers: %w", err))
+	}
+
 	consumer, err := sink.newConsumer(ctx, stream)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create consumer: %w", err)
@@ -278,20 +284,6 @@ func (s *Sink) RemoveStream(ctx context.Context, stream *Stream) error {
 	return nil
 }
 
-// removeStreamConsumer removes the stream consumer from the sink.
-func (s *Sink) removeStreamConsumer(ctx context.Context, stream *Stream) error {
-	remains, _, err := s.consumersMap[stream.Name].RemoveValues(ctx, s.Name, s.consumer)
-	if err != nil {
-		return fmt.Errorf("failed to remove consumer %s from replicated map for stream %s: %w", s.consumer, stream.Name, err)
-	}
-	if len(remains) == 0 {
-		if err := s.deleteConsumerGroup(ctx, stream); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // Close stops event polling, waits for all events to be processed, and closes the sink channel.
 // It is safe to call Close multiple times.
 func (s *Sink) Close(ctx context.Context) {
@@ -324,6 +316,76 @@ func (s *Sink) IsClosed() bool {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	return s.closed
+}
+
+// deleteStreamStaleConsumers deletes stale consumers for a specific stream.
+// s.lock must be held.
+func (s *Sink) deleteStreamStaleConsumers(ctx context.Context, stream *Stream) error {
+	// Get all consumers for this group
+	consumers, err := s.rdb.XInfoConsumers(ctx, stream.key, s.Name).Result()
+	if err != nil {
+		return fmt.Errorf("failed to get consumers info: %w", err)
+	}
+
+	// Check keep-alive map
+	keepAlives := s.consumersKeepAliveMap.Map()
+	for _, consumer := range consumers {
+		ts, hasKeepAlive := keepAlives[consumer.Name]
+		if !hasKeepAlive {
+			s.logger.Info("cleaning up consumer with no keep-alive", "consumer", consumer.Name)
+			if err := s.rdb.XGroupDelConsumer(ctx, stream.key, s.Name, consumer.Name).Err(); err != nil {
+				s.logger.Error(fmt.Errorf("failed to delete consumer with no keep-alive: %w", err), "consumer", consumer.Name)
+			}
+			continue
+		}
+
+		// Check if consumer is stale based on keep-alive timestamp
+		keepAliveTs, err := strconv.ParseInt(ts, 10, 64)
+		if err != nil {
+			s.logger.Error(fmt.Errorf("failed to parse keep-alive timestamp: %w", err), "consumer", consumer.Name, "timestamp", ts)
+			continue
+		}
+
+		if time.Since(time.Unix(0, keepAliveTs)) > 2*s.ackGracePeriod {
+			s.logger.Info("cleaning up stale consumer", "consumer", consumer.Name)
+			if err := s.rdb.XGroupDelConsumer(ctx, stream.key, s.Name, consumer.Name).Err(); err != nil {
+				s.logger.Error(fmt.Errorf("failed to delete stale consumer: %w", err), "consumer", consumer.Name)
+			}
+			if _, err := s.consumersKeepAliveMap.Delete(ctx, consumer.Name); err != nil {
+				s.logger.Error(fmt.Errorf("failed to delete keep-alive for stale consumer: %w", err), "consumer", consumer.Name)
+			}
+			if sinks := s.consumersMap[stream.Name]; sinks != nil {
+				if _, _, err := sinks.RemoveValues(ctx, s.Name, consumer.Name); err != nil {
+					s.logger.Error(fmt.Errorf("failed to remove consumer from map: %w", err), "stream", stream.Name, "consumer", consumer.Name)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// deleteStaleConsumers deletes stale consumers.
+// s.lock must be held.
+func (s *Sink) deleteStaleConsumers(ctx context.Context) {
+	for _, stream := range s.streams {
+		if err := s.deleteStreamStaleConsumers(ctx, stream); err != nil {
+			s.logger.Error(fmt.Errorf("failed to delete stale consumers for stream %s: %w", stream.Name, err))
+		}
+	}
+}
+
+// removeStreamConsumer removes the stream consumer from the sink.
+func (s *Sink) removeStreamConsumer(ctx context.Context, stream *Stream) error {
+	remains, _, err := s.consumersMap[stream.Name].RemoveValues(ctx, s.Name, s.consumer)
+	if err != nil {
+		return fmt.Errorf("failed to remove consumer %s from replicated map for stream %s: %w", s.consumer, stream.Name, err)
+	}
+	if len(remains) == 0 {
+		if err := s.deleteConsumerGroup(ctx, stream); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // newConsumer creates a new consumer and registers it in the consumers and
@@ -498,54 +560,6 @@ func (s *Sink) claimIdleMessages(ctx context.Context) {
 				break
 			}
 		}
-	}
-}
-
-// deleteStaleConsumers deletes stale consumers.
-// s.lock must be held.
-func (s *Sink) deleteStaleConsumers(ctx context.Context) {
-	keepAlives := s.consumersKeepAliveMap.Map()
-	staleConsumers := make(map[string]struct{})
-	for consumer, timestamp := range keepAlives {
-		ts, err := strconv.ParseInt(timestamp, 10, 64)
-		if err != nil {
-			s.logger.Error(fmt.Errorf("failed to parse timestamp for consumers: %w", err), "consumer", consumer)
-			continue
-		}
-		if time.Since(time.Unix(0, ts)) > 2*s.ackGracePeriod {
-			staleConsumers[consumer] = struct{}{}
-			s.logger.Debug("stale consumer", "consumer", consumer, "since", time.Since(time.Unix(0, ts)), "ttl", 2*s.ackGracePeriod)
-		}
-	}
-	// Delete any stale consumers from the consumer group.
-	for _, stream := range s.streams {
-		sinks := s.consumersMap[stream.Name]
-		for _, sink := range sinks.Keys() {
-			consumers, _ := sinks.GetValues(sink)
-			for _, consumer := range consumers {
-				if _, ok := staleConsumers[consumer]; !ok {
-					continue
-				}
-				if err := s.rdb.XGroupDelConsumer(ctx, stream.key, s.Name, consumer).Err(); err != nil {
-					s.logger.Error(fmt.Errorf("failed to delete stale consumer %s: %w", consumer, err))
-				}
-				if _, err := s.consumersKeepAliveMap.Delete(ctx, consumer); err != nil {
-					s.logger.Error(fmt.Errorf("failed to delete sink keep-alive for stale consumer %s: %w", consumer, err))
-				}
-				if _, _, err := sinks.RemoveValues(ctx, s.Name, consumer); err != nil {
-					s.logger.Error(fmt.Errorf("failed to remove consumer from map: %w", err), "stream", stream.Name, "consumer", consumer)
-				}
-				delete(staleConsumers, consumer)
-				s.logger.Debug("deleted stale consumer", "consumer", consumer)
-			}
-		}
-	}
-	// Delete any remaining stale consumers from the keep-alive map.
-	for consumer := range staleConsumers {
-		if _, err := s.consumersKeepAliveMap.Delete(ctx, consumer); err != nil {
-			s.logger.Error(fmt.Errorf("failed to delete sink keep-alive for orphaned consumer %s: %w", consumer, err))
-		}
-		s.logger.Debug("deleted orphaned consumer", "consumer", consumer)
 	}
 }
 


### PR DESCRIPTION
This PR solves a potential deadlock with maps and improves the stability and reliability of the worker pool by making several key improvements.

Worker & Job Cleanup:
- Introduces explicit worker cleanup coordination using a cleanup map to prevent races
- Adds dedicated cleanup for stale pending jobs 
- Makes worker cleanup distributed and idempotent across nodes
- Improves stream cleanup for inactive workers

Concurrency & Race Conditions:
- Fixes race conditions in SetAndWait by using per-waiter channels
- Improves goroutine lifecycle management by using logger-based contexts
- Makes node and worker stream handling more robust

Architecture:
- Renames maps for better clarity (e.g. jobsMap -> jobMap)
- Consolidates worker cleanup logic
- Adds initialization events for worker/node streams
- Makes job requeuing more reliable with retries
