### PR TITLE
Fix streaming Reader race condition

### DIFF
--- a/streaming/options/reader.go
+++ b/streaming/options/reader.go
@@ -10,12 +10,13 @@ type (
 	Reader func(*ReaderOptions)
 
 	ReaderOptions struct {
-		BlockDuration time.Duration
-		MaxPolled     int64
-		Topic         string
-		TopicPattern  string
-		BufferSize    int
-		LastEventID   string
+		BlockDuration   time.Duration
+		MaxPolled       int64
+		Topic           string
+		TopicPattern    string
+		BufferSize      int
+		LastEventID     string
+		StartExplicitly bool
 	}
 )
 
@@ -92,6 +93,14 @@ func WithReaderStartAfter(id string) Reader {
 func WithReaderStartAt(startAt time.Time) Reader {
 	return func(o *ReaderOptions) {
 		o.LastEventID = fmt.Sprintf("%d-0", startAt.UnixMilli())
+	}
+}
+
+// WithReaderStartExplicitly sets the reader to start explicitly when Start is called.
+// By default the reader starts after the first call to Subscribe.
+func WithReaderStartExplicitly() Reader {
+	return func(o *ReaderOptions) {
+		o.StartExplicitly = true
 	}
 }
 

--- a/streaming/options/reader.go
+++ b/streaming/options/reader.go
@@ -10,13 +10,12 @@ type (
 	Reader func(*ReaderOptions)
 
 	ReaderOptions struct {
-		BlockDuration   time.Duration
-		MaxPolled       int64
-		Topic           string
-		TopicPattern    string
-		BufferSize      int
-		LastEventID     string
-		StartExplicitly bool
+		BlockDuration time.Duration
+		MaxPolled     int64
+		Topic         string
+		TopicPattern  string
+		BufferSize    int
+		LastEventID   string
 	}
 )
 
@@ -93,14 +92,6 @@ func WithReaderStartAfter(id string) Reader {
 func WithReaderStartAt(startAt time.Time) Reader {
 	return func(o *ReaderOptions) {
 		o.LastEventID = fmt.Sprintf("%d-0", startAt.UnixMilli())
-	}
-}
-
-// WithReaderStartExplicitly sets the reader to start explicitly when Start is called.
-// By default the reader starts after the first call to Subscribe.
-func WithReaderStartExplicitly() Reader {
-	return func(o *ReaderOptions) {
-		o.StartExplicitly = true
 	}
 }
 


### PR DESCRIPTION
- There was a race condition between creating a `streaming.Reader` with `NewReader` and calling its `Subscribe` where events could be consumed before there is any channel to send them to.
- To fix this, the default behavior is now to only start the reader's `read` goroutine when `Subscribe` is called after it has inserted a channel that will receive events.
- Alternatively, there is now an option `WithReaderStartExplicitly` which will only start the `read` goroutine when the new `Start` is called allowing multiple calls to `Subscribe` before receiving events.