### PR TITLE
ci: enable Dependabot (gomod + actions)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: UTC
+    open-pull-requests-limit: 10
+    rebase-strategy: auto
+    reviewers: []
+    labels: ["dependencies"]
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: UTC
+    open-pull-requests-limit: 10
+    rebase-strategy: auto
+    reviewers: []
+    labels: ["dependencies"]


### PR DESCRIPTION
Add Dependabot config for Go modules and GitHub Actions with weekly schedule (Mon 06:00 UTC). YAML-only change.