### PR TITLE
Harden rmap ordering and retry ticker advances

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,75 @@
+You are a world-class distributed systems architect specialized in agentic
+architecture. You always Write ELEGANT code that follows the coding guidelines
+described in AGENTS.md. You think at a high level and do not lose track of the
+outcomes. There is no need to write backwards compatible code - we can break
+everything, instead you always aim for elegance and conceptual correctness. You
+also value LESS code and always remember cleaning up old code. Critically you
+void writing overly defensive code that hides bugs. You favor no fallbacks,
+strong contracts, elegant and conceptually correct designs.
+
+# Repository Guidelines
+
+## Common Rules
+
+### Agent Behavior
+
+- **Plan before acting**: For ≤2 files, state a brief plan then implement. For ≥3 files, write a step-by-step plan first.
+- **Read before editing**: Always read files before modifying. Search over guessing.
+- **Fix root causes**: Do not produce local workarounds—fix the real issue.
+- **Aim for simplicity**: Prefer the simplest design that satisfies the contract. Reduce surface area, delete dead paths, and avoid introducing new concepts unless they pay for themselves.
+- **Be concise**: Give short status updates during multi-step work. Present a short summary when done.
+- **Default to repo-style formatting**: Prefer small, composable functions and well-factored files; keep “main logic first, helpers last”; add meaningful header comments; and fix lints immediately.
+- **Comment intent and contracts**: If you add or significantly change logic, you MUST add/maintain comments so a reader can understand the *why* without reconstructing it from code.
+ - **File header comment**: Any non-trivial package/file (new executor, planner, compiler, adapter, protocol layer, etc.) must start with a short header comment explaining purpose, invariants, and the contract with adjacent layers.
+ - **Non-trivial helpers (including private)**: Any helper whose behavior is not obvious from the name must have a short contract comment (inputs/outputs, invariants, failure modes, and why it exists). This applies equally to unexported functions/methods—private does not mean undocumented, especially in boundary adapters (DB clients, transports, codecs).
+  - **No comment-free non-trivial files**: A file with meaningful logic should never land with “0 comments”.
+- **Maintain README**: Proactively update the READMEs when introducing user-facing changes or new major features. 
+
+### Go Code Style
+
+- **Go 1.24+**. Format with `go fmt ./...`.
+- **Imports**: Group stdlib separate from external. Let gofmt manage ordering.
+- **Files**: Use `lower_snake_case.go`. Keep ≤1000 lines; split proactively.
+- **Naming**: Packages are lowercase and short. Exported identifiers need GoDoc. Avoid stutter.
+- **Types**: Use `any` over `interface{}`. Prefer concrete types over `interface{}`.
+- **Errors**: Wrap with `%w`. Use `errors.Is/As`. **Never ignore errors or use `_ = call()`**.
+- **Signatures**: Keep on one line when ≤100 columns. Only wrap genuinely long signatures.
+- **Slice/map nil**: Do not check nil before `len`. `len(nil)` returns 0. Use `len(x) == 0` directly.
+
+### Code Blocks and Literals
+
+- Always place a newline after `{` and before `}` for `if`, `for`, `switch`, `func`, `type`.
+- No single-line blocks: `if cond { do() }` → use multiple lines.
+- Short struct literals are fine inline: `&T{A: 1}`. Break long literals to one field per line with trailing commas.
+
+### File Organization
+
+Order declarations as:
+1. Types (public, then private) in a single `type (...)` block when practical
+2. Constants (public, then private)
+3. Variables (public, then private)
+4. Public functions
+5. Public methods
+6. Private functions
+7. Private methods
+
+**Within each category**, order by relevance — main logic first, helpers last:
+- Primary entry points and feature implementations first
+- Domain-specific supporting functions next
+- Generic utilities and conversion helpers last
+
+Additional formatting defaults (apply unless there is a strong reason not to):
+- **Types at the top**: Place new helper types close to the code they support, but keep all type declarations in the file’s top type block.
+- **Avoid anonymous functions**: Prefer named helpers or small method receivers over closures, especially for concurrency (e.g., `errgroup.Go(job.Run)`).
+- **Break down complexity**: Split large functions into smaller, testable helpers with clear contracts; split files when they start to accrete multiple distinct concerns (ideally keep ≤1000 lines).
+- **Reuse-first**: Before adding new helpers, check for existing shared utilities; when you do add a helper, make it reusable and name it for the domain (not the immediate caller).
+- **Meaningful header comments**: Exported identifiers require GoDoc; non-trivial helpers should have short intent/contract comments when they aren’t obvious from the name.
+
+### Error Handling & Contracts
+
+- **Always check errors**. Never discard with `_`.
+- **Strong contracts**: Goa validates payloads at boundaries. Do not re-validate inside service code.
+- **No defensive programming**: Do not add nil/empty guards for values guaranteed by construction, Goa, or prior validation.
+- **No blanket string normalization**: Do not sprinkle `strings.TrimSpace` (or similar) throughout internal code paths. Trimming changes semantics and can hide producer bugs. Only normalize whitespace at a boundary when the external contract explicitly treats whitespace as insignificant (e.g., parsing user input or third‑party payloads) and keep that normalization localized.
+- **Validate only at boundaries**: HTTP/gRPC handlers, event consumers, DB results, third-party APIs, `ctx.Value()`, type assertions, required map lookups.
+- **Fail fast**: Unexpected states are bugs. Return precise errors or panic—do not silently recover or skip.

--- a/pool/ticker.go
+++ b/pool/ticker.go
@@ -29,6 +29,13 @@ type (
 	}
 )
 
+const (
+	// tickerRetryMaxInterval caps how long a local ticker waits before retrying
+	// a failed Redis advance. A transient Redis outage must not leave the
+	// distributed ticker permanently idle until some unrelated map event arrives.
+	tickerRetryMaxInterval = time.Second
+)
+
 // NewTicker returns a new Ticker that behaves similarly to time.Ticker, but
 // instead delivers the current time on the channel to only one of the nodes
 // that invoked NewTicker with the same name.
@@ -166,7 +173,7 @@ func (t *Ticker) handleTick() {
 	next := serialize(ts, d)
 	prev, err := t.tickerMap.TestAndSet(context.Background(), t.name, t.next, next)
 	if err != nil {
-		t.logger.Error(err, "msg", "failed to update next tick")
+		t.handleAdvanceFailureLocked(err, d)
 		return
 	}
 	if prev != t.next {
@@ -186,7 +193,20 @@ func (t *Ticker) handleTick() {
 // initTimer sets the timer to fire at the next tick.
 func (t *Ticker) initTimer() {
 	next, _ := deserialize(t.next)
-	d := time.Until(next)
+	t.resetTimerLocked(time.Until(next))
+}
+
+// handleAdvanceFailureLocked logs a transient Redis advance failure and rearms
+// the timer so the ticker retries instead of staying permanently idle. The
+// caller must hold t.lock.
+func (t *Ticker) handleAdvanceFailureLocked(err error, interval time.Duration) {
+	t.logger.Error(err, "msg", "failed to update next tick")
+	t.resetTimerLocked(min(interval, tickerRetryMaxInterval))
+}
+
+// resetTimerLocked arms the local timer to fire after d. The caller must hold
+// t.lock.
+func (t *Ticker) resetTimerLocked(d time.Duration) {
 	if d < 0 {
 		d = 0
 	}

--- a/pool/ticker_test.go
+++ b/pool/ticker_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"goa.design/clue/log"
+	"goa.design/pulse/pulse"
+	"goa.design/pulse/rmap"
 
 	ptesting "goa.design/pulse/testing"
 )
@@ -95,6 +97,53 @@ func TestReplaceTickerTimer(t *testing.T) {
 
 	// Cleanup
 	assert.NoError(t, node.Shutdown(ctx))
+}
+
+func TestHandleTickRetriesAfterMapWriteError(t *testing.T) {
+	rdb := ptesting.NewRedisClient(t)
+	defer ptesting.CleanupRedis(t, rdb, false, t.Name())
+	ctx := log.Context(ptesting.NewTestContext(t), log.WithOutput(io.Discard))
+	testName := strings.Replace(t.Name(), "/", "_", -1)
+
+	tickerMap, err := rmap.Join(ctx, "ticker-map-"+testName, rdb)
+	require.NoError(t, err)
+
+	tickDuration := 10 * time.Millisecond
+	next := serialize(time.Now().Add(tickDuration), tickDuration)
+	_, err = tickerMap.Set(ctx, testName, next)
+	require.NoError(t, err)
+
+	c := make(chan time.Time, 1)
+	ticker := &Ticker{
+		C:         c,
+		c:         c,
+		name:      testName,
+		tickerMap: tickerMap,
+		next:      next,
+		timer:     time.NewTimer(time.Hour),
+		logger:    pulse.NoopLogger(),
+	}
+	t.Cleanup(func() {
+		ticker.timer.Stop()
+	})
+
+	tickerMap.Close()
+
+	start := time.Now()
+	ticker.handleTick()
+
+	select {
+	case firedAt := <-ticker.timer.C:
+		assert.WithinDuration(t, start.Add(tickDuration), firedAt, 50*time.Millisecond)
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("ticker did not schedule a retry after a map write error")
+	}
+
+	select {
+	case <-ticker.C:
+		t.Fatal("ticker should not emit a tick when advancing the map fails")
+	default:
+	}
 }
 
 // verifyTickerStopped checks if a ticker has stopped by waiting for a duration longer than its tick interval

--- a/rmap/README.md
+++ b/rmap/README.md
@@ -49,8 +49,9 @@ Redis hash backing a map:
 
 [![Replicated Map Append](../snippets/rmap-append.png)](../examples/rmap/basics/main.go#L60-L72)
 
-Values are stored as strings. The `AppendValues` method converts the values to a
-comma separated string before storing them. 
+Values are stored as strings. The list helpers store list values as JSON arrays
+so appends, uniqueness checks, and removals can round-trip without losing item
+boundaries.
 
 * The `Inc` method increments a counter by a given amount and returns the new value.
 

--- a/rmap/map.go
+++ b/rmap/map.go
@@ -1,3 +1,5 @@
+// Package rmap maintains a Redis-backed replicated map whose local state is
+// ordered by monotonic revisions and updated through pubsub notifications.
 package rmap
 
 import (
@@ -56,29 +58,39 @@ type (
 		closed  bool // true if Close returned - used by tests
 
 		wlock   sync.Mutex
-		waiters sync.Map // map of key to []*setWaiter
+		waiters map[uint64][]*setWaiter // keyed by committed revision
 	}
 
 	// EventKind is the type of map event.
 	EventKind int
 
-	// setNotification is the type of internal notification sent when a key is set.
-	setNotification struct {
-		key   string
-		value string
+	// mapChange captures the event kind and revision applied to the local replica.
+	mapChange struct {
+		kind EventKind
+		rev  uint64
 	}
 
-	// setWaiter represents a waiting SetAndWait operation
+	// setResult is the previous value and committed revision returned by Set.
+	setResult struct {
+		prev    string
+		existed bool
+		rev     uint64
+	}
+
+	// setWaiter tracks a SetAndWait call until the local replica observes at
+	// least the committed revision returned by the write.
 	setWaiter struct {
-		ch     chan setNotification
-		key    string
-		value  string
+		ch     chan struct{}
+		rev    uint64
 		ctx    context.Context // context for cancellation
 		cancel func()          // cleanup function
 	}
 )
 
-const revField = "=rev"
+const (
+	revField  = "=rev"
+	kindField = "=kind"
+)
 
 const (
 	// EventChange is the event emitted when a key is added or changed.
@@ -130,6 +142,7 @@ func Join(ctx context.Context, name string, rdb *redis.Client, opts ...MapOption
 		logger:               o.Logger.WithPrefix("map", name),
 		rdb:                  rdb,
 		content:              make(map[string]string),
+		waiters:              make(map[uint64][]*setWaiter),
 		setScript:            luaSet,
 		testAndSetScript:     luaTestAndSet,
 		setIfNotExistsScript: luaSetIfNotExists,
@@ -249,33 +262,27 @@ func (sm *Map) GetValues(key string) ([]string, bool) {
 // Set(ctx, "color", "blue") would set the "color" key to "blue"
 // and return the previous value, if any.
 func (sm *Map) Set(ctx context.Context, key, value string) (string, error) {
-	prev, err := sm.runLuaScript(ctx, "set", sm.setScript, key, value)
+	res, err := sm.runSetScript(ctx, key, value)
 	if err != nil {
 		return "", err
 	}
-	if prev == nil {
-		return "", nil
-	}
-	return prev.(string), nil
+	return res.prev, nil
 }
 
 // SetEx sets the value for the given key and returns the previous value along
 // with a flag indicating whether the key previously existed.
 func (sm *Map) SetEx(ctx context.Context, key, value string) (string, bool, error) {
-	prev, err := sm.runLuaScript(ctx, "set", sm.setScript, key, value)
+	res, err := sm.runSetScript(ctx, key, value)
 	if err != nil {
 		return "", false, err
 	}
-	if prev == nil {
-		return "", false, nil
-	}
-	return prev.(string), true, nil
+	return res.prev, res.existed, nil
 }
 
-// SetAndWait is a convenience method that calls Set and waits for the update to be
-// applied and the notification to be sent. Multiple concurrent calls with the same
-// key and value are allowed - each call will receive its own notification when the
-// update is applied.
+// SetAndWait is a convenience method that calls Set and waits until the local
+// replica has observed the committed revision. Multiple concurrent calls with
+// the same key and value are allowed because each waiter is tied to its own
+// committed write rather than the final key/value pair.
 //
 // The method will return an error if:
 // - The key is empty
@@ -284,56 +291,25 @@ func (sm *Map) SetEx(ctx context.Context, key, value string) (string, bool, erro
 // - The map is stopped
 // - There's an issue with the Redis operation
 func (sm *Map) SetAndWait(ctx context.Context, key, value string) (string, error) {
-	notifyCh := make(chan setNotification, 1)
+	res, err := sm.runSetScript(ctx, key, value)
+	if err != nil {
+		return "", err
+	}
 
-	// Create cancellable context for cleanup
+	notifyCh := make(chan struct{}, 1)
 	waitCtx, cancel := context.WithCancel(ctx)
 	waiter := &setWaiter{
 		ch:     notifyCh,
-		key:    key,
-		value:  value,
+		rev:    res.rev,
 		ctx:    waitCtx,
 		cancel: cancel,
 	}
-
 	defer func() {
-		// Cancel first so notifiers prefer to drop any late sends.
 		cancel()
-
-		// Remove waiter under lock
-		sm.wlock.Lock()
-		if v, ok := sm.waiters.Load(key); ok {
-			waiters := v.([]*setWaiter)
-			newWaiters := make([]*setWaiter, 0, len(waiters))
-			for _, w := range waiters {
-				if w != waiter {
-					newWaiters = append(newWaiters, w)
-				}
-			}
-			if len(newWaiters) > 0 {
-				sm.waiters.Store(key, newWaiters)
-			} else {
-				sm.waiters.Delete(key)
-			}
-		}
-		sm.wlock.Unlock()
+		sm.removeWaiter(waiter)
 	}()
-
-	// Prepare new waiters list under lock
-	sm.wlock.Lock()
-	if v, ok := sm.waiters.Load(key); ok {
-		waiters := v.([]*setWaiter)
-		newWaiters := append(append([]*setWaiter(nil), waiters...), waiter) // Note: need to copy to avoid data race
-		sm.waiters.Store(key, newWaiters)
-	} else {
-		sm.waiters.Store(key, []*setWaiter{waiter})
-	}
-	sm.wlock.Unlock()
-
-	// Call Set - if it fails, the deferred cleanup will remove our waiter
-	prev, err := sm.Set(ctx, key, value)
-	if err != nil {
-		return "", err
+	if sm.registerWaiter(waiter) {
+		return res.prev, nil
 	}
 
 	// Wait for notification or context cancellation
@@ -342,12 +318,8 @@ func (sm *Map) SetAndWait(ctx context.Context, key, value string) (string, error
 		return "", ctx.Err()
 	case <-sm.done:
 		return "", fmt.Errorf("pulse map: %s is stopped", sm.Name)
-	case ev := <-notifyCh:
-		if ev.key == key && ev.value == value {
-			return prev, nil
-		}
-		// This shouldn't happen as we only send matching notifications
-		return "", fmt.Errorf("pulse map: received unexpected notification key=%s value=%s", ev.key, ev.value)
+	case <-notifyCh:
+		return res.prev, nil
 	}
 }
 
@@ -586,14 +558,15 @@ func (sm *Map) TestAndDeleteEx(ctx context.Context, key, test string) (prev stri
 	return prev, existed, deleted, nil
 }
 
-// Reset clears the map content. Reset is the only method that can be called
-// after the map is closed.
+// Reset clears the map content. Reset remains available after Close because it
+// mutates Redis state even though the local replica is already frozen.
 func (sm *Map) Reset(ctx context.Context) error {
 	_, err := sm.runLuaScript(ctx, "reset", sm.resetScript, "*")
 	return err
 }
 
-// Destroy deletes the map content from Redis and notifies subscribers.
+// Destroy clears the map content from Redis and notifies subscribers while
+// preserving the internal revision ordering used by live replicas.
 func (sm *Map) Destroy(ctx context.Context) error {
 	_, err := sm.runLuaScript(ctx, "destroy", sm.destroyScript, "*")
 	return err
@@ -659,13 +632,12 @@ func (sm *Map) Close() {
 
 	// Clean up all waiters
 	sm.wlock.Lock()
-	sm.waiters.Range(func(key, value interface{}) bool {
-		waiters := value.([]*setWaiter)
+	for rev, waiters := range sm.waiters {
 		for _, w := range waiters {
 			w.cancel()
 		}
-		return true
-	})
+		delete(sm.waiters, rev)
+	}
 	sm.wlock.Unlock()
 	sm.lock.Lock()
 	sm.closed = true
@@ -715,7 +687,7 @@ func (sm *Map) init(ctx context.Context) error {
 		return fmt.Errorf("pulse map: %s failed to read initial content: %w", sm.Name, err)
 	}
 	sm.content = cmd.Val()
-	sm.rev = extractRevision(sm.content)
+	sm.rev, _ = extractState(sm.content)
 
 	return nil
 }
@@ -740,100 +712,18 @@ func (sm *Map) run() {
 			}
 			op, data := parts[0], []byte(parts[1])
 			sm.lock.Lock()
-			kind := EventChange
-			var notification *setNotification
-			switch op {
-			case "reset":
-				if rev, ok := parseRevisionString(string(data)); ok && rev <= sm.rev {
-					sm.lock.Unlock()
-					continue
-				} else if ok {
-					sm.rev = rev
-				}
-				sm.content = make(map[string]string)
-				sm.logger.Debug("reset")
-				kind = EventReset
-			case "del":
-				key, rest, err := unpackString(data)
-				if err != nil {
-					sm.logger.Error(fmt.Errorf("invalid del payload"), "payload", msg.Payload, "error", err)
-					sm.lock.Unlock()
-					continue
-				}
-				if key == revField {
-					sm.lock.Unlock()
-					continue
-				}
-				if rev, ok := unpackRevision(rest); ok {
-					if rev <= sm.rev {
-						sm.lock.Unlock()
-						continue
-					}
-					sm.rev = rev
-				}
-				delete(sm.content, key)
-				sm.logger.Debug("deleted", "key", key)
-				kind = EventDelete
-			case "set":
-				key, rest, err := unpackString(data)
-				if err != nil {
-					sm.logger.Error(fmt.Errorf("invalid set key"), "payload", msg.Payload, "error", err)
-					sm.lock.Unlock()
-					continue
-				}
-				if key == revField {
-					sm.lock.Unlock()
-					continue
-				}
-				val, rest, err := unpackString(rest)
-				if err != nil {
-					sm.logger.Error(fmt.Errorf("invalid set value"), "payload", msg.Payload, "error", err)
-					sm.lock.Unlock()
-					continue
-				}
-				if rev, ok := unpackRevision(rest); ok {
-					if rev <= sm.rev {
-						sm.lock.Unlock()
-						continue
-					}
-					sm.rev = rev
-				}
-				sm.content[key] = val
-				notification = &setNotification{key: key, value: val}
-				sm.logger.Debug("set", "key", key, "val", val)
+			change, applied, err := sm.applyMessageLocked(op, data)
+			if err != nil {
+				sm.logger.Error(err, "payload", msg.Payload)
+				sm.lock.Unlock()
+				continue
 			}
-
-			for _, c := range sm.chans {
-				select {
-				case c <- kind:
-				default:
-				}
+			if applied {
+				sm.notifySubscribers(change.kind)
 			}
 			sm.lock.Unlock()
-
-			// For set operations, notify waiters after releasing lock
-			if notification != nil {
-				// Load waiters for this key
-				if w, ok := sm.waiters.Load(notification.key); ok {
-					// Take lock only while reading waiters list
-					sm.wlock.Lock()
-					waiters := w.([]*setWaiter)
-					sm.wlock.Unlock()
-
-					// Notify matching waiters - no lock needed as each waiter has its own channel
-					for _, waiter := range waiters {
-						if waiter.key == notification.key && waiter.value == notification.value {
-							select {
-							case waiter.ch <- *notification:
-							case <-waiter.ctx.Done():
-								// Waiter was cancelled or timed out
-								continue
-							default:
-								// Non-blocking to avoid stalling the map loop if the waiter is no longer receiving.
-							}
-						}
-					}
-				}
+			if applied {
+				sm.notifyWaitersUpTo(change.rev)
 			}
 
 		case <-sm.done:
@@ -857,8 +747,9 @@ func (sm *Map) run() {
 	}
 }
 
-// runLuaScript runs the given Lua script, the first argument must be the key.
-// It is the caller's responsibility to make sure the map is locked.
+// runLuaScript validates the user key and executes the given Lua script. Reset
+// and Destroy remain available after Close because they mutate Redis state even
+// when the local replica is already frozen.
 func (sm *Map) runLuaScript(ctx context.Context, name string, script *redis.Script, args ...any) (any, error) {
 	sm.lock.RLock()
 	if sm.closing && name != "reset" && name != "destroy" {
@@ -961,8 +852,13 @@ func (sm *Map) reconnect() {
 		// while reading the snapshot under the same lock so readers never observe
 		// intermediate state regressions. Revisioned messages at or below the
 		// snapshot revision are ignored.
+		oldRev := sm.rev
 		sm.content = cmd.Val()
-		sm.rev = extractRevision(sm.content)
+		recoveredKind := EventChange
+		sm.rev, recoveredKind = extractState(sm.content)
+		if sm.rev <= oldRev {
+			recoveredKind = EventChange
+		}
 		drainErr := false
 		for {
 			select {
@@ -977,54 +873,13 @@ func (sm *Map) reconnect() {
 					continue
 				}
 				op, data := parts[0], []byte(parts[1])
-				switch op {
-				case "reset":
-					if rev, ok := parseRevisionString(string(data)); ok && rev <= sm.rev {
-						continue
-					} else if ok {
-						sm.rev = rev
-					}
-					sm.content = make(map[string]string)
-					sm.logger.Debug("reset")
-				case "del":
-					key, rest, err := unpackString(data)
-					if err != nil {
-						sm.logger.Error(fmt.Errorf("invalid del payload"), "payload", msg.Payload, "error", err)
-						continue
-					}
-					if key == revField {
-						continue
-					}
-					if rev, ok := unpackRevision(rest); ok {
-						if rev <= sm.rev {
-							continue
-						}
-						sm.rev = rev
-					}
-					delete(sm.content, key)
-					sm.logger.Debug("deleted", "key", key)
-				case "set":
-					key, rest, err := unpackString(data)
-					if err != nil {
-						sm.logger.Error(fmt.Errorf("invalid set key"), "payload", msg.Payload, "error", err)
-						continue
-					}
-					if key == revField {
-						continue
-					}
-					val, rest, err := unpackString(rest)
-					if err != nil {
-						sm.logger.Error(fmt.Errorf("invalid set value"), "payload", msg.Payload, "error", err)
-						continue
-					}
-					if rev, ok := unpackRevision(rest); ok {
-						if rev <= sm.rev {
-							continue
-						}
-						sm.rev = rev
-					}
-					sm.content[key] = val
-					sm.logger.Debug("set", "key", key, "val", val)
+				change, applied, err := sm.applyMessageLocked(op, data)
+				if err != nil {
+					sm.logger.Error(err, "payload", msg.Payload)
+					continue
+				}
+				if applied {
+					recoveredKind = strongerEventKind(recoveredKind, change.kind)
 				}
 			default:
 				goto drained
@@ -1049,51 +904,17 @@ func (sm *Map) reconnect() {
 		oldSub := sm.sub
 		sm.sub = sub
 		sm.msgch = msgch
-		for _, c := range sm.chans {
-			select {
-			case c <- EventChange:
-			default:
-			}
-		}
+		sm.notifySubscribers(recoveredKind)
 		sm.lock.Unlock()
 		if oldSub != nil {
 			_ = oldSub.Close()
 		}
 
-		sm.satisfyWaiters()
+		sm.notifyWaitersUpTo(sm.rev)
 
 		sm.logger.Info("reconnected")
 		return
 	}
-}
-
-func (sm *Map) satisfyWaiters() {
-	sm.waiters.Range(func(key, value any) bool {
-		k, ok := key.(string)
-		if !ok {
-			return true
-		}
-		sm.lock.RLock()
-		v, ok := sm.content[k]
-		sm.lock.RUnlock()
-		if !ok {
-			return true
-		}
-		waiters, ok := value.([]*setWaiter)
-		if !ok {
-			return true
-		}
-		for _, waiter := range waiters {
-			if waiter.key == k && waiter.value == v {
-				select {
-				case waiter.ch <- setNotification{key: k, value: v}:
-				case <-waiter.ctx.Done():
-				default:
-				}
-			}
-		}
-		return true
-	})
 }
 
 // redisKeyRegex is a regular expression that matches valid Redis keys.
@@ -1136,23 +957,28 @@ func parseRevisionString(s string) (uint64, bool) {
 	return rev, true
 }
 
-func extractRevision(content map[string]string) uint64 {
+func extractState(content map[string]string) (uint64, EventKind) {
 	if content == nil {
-		return 0
+		return 0, EventChange
+	}
+	kind := EventChange
+	if s, ok := content[kindField]; ok {
+		kind = parseStoredKind(s)
+		delete(content, kindField)
 	}
 	s, ok := content[revField]
 	if !ok {
-		return 0
+		return 0, kind
 	}
 	delete(content, revField)
 	if s == "" {
-		return 0
+		return 0, kind
 	}
 	rev, ok := parseRevisionString(s)
 	if !ok {
-		return 0
+		return 0, kind
 	}
-	return rev
+	return rev, kind
 }
 
 func unpackRevision(data []byte) (uint64, bool) {
@@ -1164,4 +990,209 @@ func unpackRevision(data []byte) (uint64, bool) {
 		return 0, false
 	}
 	return parseRevisionString(s)
+}
+
+// runSetScript executes the Set Lua script and returns the previous value plus
+// the committed revision observed by Redis.
+func (sm *Map) runSetScript(ctx context.Context, key, value string) (setResult, error) {
+	raw, err := sm.runLuaScript(ctx, "set", sm.setScript, key, value)
+	if err != nil {
+		return setResult{}, err
+	}
+	values, ok := raw.([]any)
+	if !ok || len(values) != 3 {
+		return setResult{}, fmt.Errorf("pulse map: %s returned invalid set result %T", sm.Name, raw)
+	}
+	existed, ok := values[0].(int64)
+	if !ok {
+		return setResult{}, fmt.Errorf("pulse map: %s returned invalid set existence flag %T", sm.Name, values[0])
+	}
+	prev, ok := values[1].(string)
+	if !ok {
+		return setResult{}, fmt.Errorf("pulse map: %s returned invalid set previous value %T", sm.Name, values[1])
+	}
+	revString, ok := values[2].(string)
+	if !ok {
+		return setResult{}, fmt.Errorf("pulse map: %s returned invalid set revision %T", sm.Name, values[2])
+	}
+	rev, ok := parseRevisionString(revString)
+	if !ok {
+		return setResult{}, fmt.Errorf("pulse map: %s returned invalid set revision %q", sm.Name, revString)
+	}
+	return setResult{prev: prev, existed: existed == 1, rev: rev}, nil
+}
+
+// registerWaiter installs a waiter unless the local replica has already caught
+// up to the committed revision it targets.
+func (sm *Map) registerWaiter(waiter *setWaiter) bool {
+	sm.wlock.Lock()
+	defer sm.wlock.Unlock()
+	sm.lock.RLock()
+	defer sm.lock.RUnlock()
+	if sm.rev >= waiter.rev {
+		return true
+	}
+	sm.waiters[waiter.rev] = append(sm.waiters[waiter.rev], waiter)
+	return false
+}
+
+// removeWaiter unregisters a waiter after SetAndWait returns or is canceled.
+func (sm *Map) removeWaiter(waiter *setWaiter) {
+	sm.wlock.Lock()
+	defer sm.wlock.Unlock()
+	waiters, ok := sm.waiters[waiter.rev]
+	if !ok {
+		return
+	}
+	filtered := waiters[:0]
+	for _, current := range waiters {
+		if current != waiter {
+			filtered = append(filtered, current)
+		}
+	}
+	if len(filtered) == 0 {
+		delete(sm.waiters, waiter.rev)
+		return
+	}
+	sm.waiters[waiter.rev] = filtered
+}
+
+// notifyWaitersUpTo releases every waiter whose committed revision is now
+// visible in the local replica.
+func (sm *Map) notifyWaitersUpTo(rev uint64) {
+	sm.wlock.Lock()
+	var ready []*setWaiter
+	for waiterRev, waiters := range sm.waiters {
+		if waiterRev > rev {
+			continue
+		}
+		ready = append(ready, waiters...)
+		delete(sm.waiters, waiterRev)
+	}
+	sm.wlock.Unlock()
+	for _, waiter := range ready {
+		select {
+		case waiter.ch <- struct{}{}:
+		case <-waiter.ctx.Done():
+		default:
+		}
+	}
+}
+
+// notifySubscribers sends a best-effort notification to every subscriber while
+// the map lock is held, so the subscriber list stays stable during iteration.
+func (sm *Map) notifySubscribers(kind EventKind) {
+	for _, c := range sm.chans {
+		select {
+		case c <- kind:
+		default:
+		}
+	}
+}
+
+// applyMessageLocked applies one pubsub message to the local replica. The map
+// lock must be held and the returned revision is the highest revision observed
+// after the update is applied.
+func (sm *Map) applyMessageLocked(op string, data []byte) (mapChange, bool, error) {
+	switch op {
+	case "destroy":
+		rev, ok := parseRevisionString(string(data))
+		if !ok {
+			return mapChange{}, false, fmt.Errorf("invalid destroy payload")
+		}
+		if rev <= sm.rev {
+			return mapChange{}, false, nil
+		}
+		sm.rev = rev
+		sm.content = make(map[string]string)
+		sm.logger.Debug("destroy")
+		return mapChange{kind: EventReset, rev: rev}, true, nil
+	case "reset":
+		rev, ok := parseRevisionString(string(data))
+		if !ok {
+			return mapChange{}, false, fmt.Errorf("invalid reset payload")
+		}
+		if rev <= sm.rev {
+			return mapChange{}, false, nil
+		}
+		sm.rev = rev
+		sm.content = make(map[string]string)
+		sm.logger.Debug("reset")
+		return mapChange{kind: EventReset, rev: rev}, true, nil
+	case "del":
+		key, rest, err := unpackString(data)
+		if err != nil {
+			return mapChange{}, false, fmt.Errorf("invalid del payload: %w", err)
+		}
+		if key == revField || key == kindField {
+			return mapChange{}, false, nil
+		}
+		rev, ok := unpackRevision(rest)
+		if !ok {
+			return mapChange{}, false, fmt.Errorf("invalid del revision")
+		}
+		if rev <= sm.rev {
+			return mapChange{}, false, nil
+		}
+		sm.rev = rev
+		delete(sm.content, key)
+		sm.logger.Debug("deleted", "key", key)
+		return mapChange{kind: EventDelete, rev: rev}, true, nil
+	case "set":
+		key, rest, err := unpackString(data)
+		if err != nil {
+			return mapChange{}, false, fmt.Errorf("invalid set key: %w", err)
+		}
+		if key == revField || key == kindField {
+			return mapChange{}, false, nil
+		}
+		val, rest, err := unpackString(rest)
+		if err != nil {
+			return mapChange{}, false, fmt.Errorf("invalid set value: %w", err)
+		}
+		rev, ok := unpackRevision(rest)
+		if !ok {
+			return mapChange{}, false, fmt.Errorf("invalid set revision")
+		}
+		if rev <= sm.rev {
+			return mapChange{}, false, nil
+		}
+		sm.rev = rev
+		sm.content[key] = val
+		sm.logger.Debug("set", "key", key, "val", val)
+		return mapChange{kind: EventChange, rev: rev}, true, nil
+	default:
+		return mapChange{}, false, fmt.Errorf("invalid payload")
+	}
+}
+
+func parseStoredKind(kind string) EventKind {
+	switch kind {
+	case "del":
+		return EventDelete
+	case "destroy", "reset":
+		return EventReset
+	default:
+		return EventChange
+	}
+}
+
+func strongerEventKind(current, next EventKind) EventKind {
+	if eventPriority(next) > eventPriority(current) {
+		return next
+	}
+	return current
+}
+
+func eventPriority(kind EventKind) int {
+	switch kind {
+	case EventReset:
+		return 3
+	case EventDelete:
+		return 2
+	case EventChange:
+		return 1
+	default:
+		return 0
+	}
 }

--- a/rmap/map_test.go
+++ b/rmap/map_test.go
@@ -1,3 +1,5 @@
+// Package rmap tests the Redis-backed replicated map contracts, including the
+// internal recovery invariants that keep local replicas and waiters consistent.
 package rmap
 
 import (
@@ -847,6 +849,112 @@ func TestReconnect(t *testing.T) {
 
 	// Check that the new value is eventually available
 	assert.Eventually(t, func() bool { return len(m.Map()) == 2 }, wf, tck)
+}
+
+func TestDestroyAllowsReuse(t *testing.T) {
+	rdb := redis.NewClient(&redis.Options{Addr: redisAddr, Password: redisPwd})
+	ctx := context.Background()
+
+	m, err := Join(ctx, "destroy-reuse", rdb)
+	require.NoError(t, err)
+	defer cleanup(t, m)
+
+	_, err = m.Set(ctx, "before", "1")
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		v, ok := m.Get("before")
+		return ok && v == "1"
+	}, wf, tck)
+
+	require.NoError(t, m.Destroy(ctx))
+	require.Eventually(t, func() bool { return len(m.Map()) == 0 }, wf, tck)
+
+	_, err = m.Set(ctx, "after", "2")
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		v, ok := m.Get("after")
+		return ok && v == "2"
+	}, wf, tck)
+}
+
+func TestApplyMessageLockedRejectsDestroyWithoutRevision(t *testing.T) {
+	sm := &Map{
+		content: map[string]string{"stale": "value"},
+		logger:  pulse.NoopLogger(),
+		rev:     7,
+	}
+
+	change, applied, err := sm.applyMessageLocked("destroy", nil)
+
+	require.Error(t, err)
+	assert.False(t, applied)
+	assert.Equal(t, mapChange{}, change)
+	assert.Equal(t, uint64(7), sm.rev)
+	assert.Equal(t, map[string]string{"stale": "value"}, sm.content)
+}
+
+func TestReconnectPreservesResetEvent(t *testing.T) {
+	rdb := redis.NewClient(&redis.Options{Addr: redisAddr, Password: redisPwd})
+	ctx := context.Background()
+
+	observer, err := Join(ctx, "reconnect-reset-event", rdb)
+	require.NoError(t, err)
+	defer cleanup(t, observer)
+
+	writer, err := Join(ctx, "reconnect-reset-event", rdb)
+	require.NoError(t, err)
+	defer writer.Close()
+
+	require.NoError(t, observer.Reset(ctx))
+	_, err = writer.Set(ctx, "k", "v")
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		v, ok := observer.Get("k")
+		return ok && v == "v"
+	}, wf, tck)
+
+	ch := observer.Subscribe()
+	require.NotNil(t, ch)
+
+	observer.lock.RLock()
+	require.NoError(t, observer.sub.Close())
+
+	require.NoError(t, writer.Reset(ctx))
+
+	observer.lock.RUnlock()
+
+	select {
+	case ev := <-ch:
+		require.Equal(t, EventReset, ev)
+	case <-time.After(wf):
+		t.Fatal("timed out waiting for reconnect reset event")
+	}
+}
+
+func TestNotifyWaitersUpToReleasesCommittedWriteAfterOverwrite(t *testing.T) {
+	// Recovery must unblock a committed SetAndWait even when a later revision has
+	// already advanced the key to a different value. Revision-based waiting keeps
+	// the acknowledgement tied to the committed write rather than the final value.
+	sm := &Map{waiters: make(map[uint64][]*setWaiter)}
+
+	waitCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	notifyCh := make(chan struct{}, 1)
+	sm.waiters[4] = []*setWaiter{{
+		ch:     notifyCh,
+		rev:    4,
+		ctx:    waitCtx,
+		cancel: cancel,
+	}}
+
+	sm.notifyWaitersUpTo(5)
+
+	select {
+	case <-notifyCh:
+	default:
+		t.Fatal("expected recovery to release waiter after committed write")
+	}
 }
 
 func cleanup(t *testing.T, m *Map) {

--- a/rmap/options.go
+++ b/rmap/options.go
@@ -1,3 +1,5 @@
+// Package rmap options keep map construction small and explicit so the runtime
+// behavior stays easy to reason about at every call site.
 package rmap
 
 import (

--- a/rmap/scripts.go
+++ b/rmap/scripts.go
@@ -1,3 +1,5 @@
+// Package rmap keeps every replicated-map mutation in Lua so Redis updates,
+// revision bumps, and pubsub notifications stay atomic and totally ordered.
 package rmap
 
 import "github.com/redis/go-redis/v9"
@@ -32,6 +34,7 @@ var (
 	   local encoded = cjson.encode(values)
 	   redis.call("HSET", KEYS[1], key, encoded)
 	   local rev = tostring(redis.call("HINCRBY", KEYS[1], "=rev", 1))
+	   redis.call("HSET", KEYS[1], "=kind", "set")
 	   local msg = struct.pack("ic0ic0ic0", string.len(key), key, string.len(encoded), encoded, string.len(rev), rev)
 	   redis.call("PUBLISH", KEYS[2], "set:" .. msg)
 	   return encoded
@@ -78,6 +81,7 @@ var (
 	     local encoded = cjson.encode(values)
 	     redis.call("HSET", KEYS[1], key, encoded)
 	     local rev = tostring(redis.call("HINCRBY", KEYS[1], "=rev", 1))
+	     redis.call("HSET", KEYS[1], "=kind", "set")
 	     local msg = struct.pack("ic0ic0ic0", string.len(key), key, string.len(encoded), encoded, string.len(rev), rev)
 	     redis.call("PUBLISH", KEYS[2], "set:" .. msg)
 	     return encoded
@@ -90,8 +94,12 @@ var (
 	// value.
 	luaDelete = redis.NewScript(`
 	   local v = redis.call("HGET", KEYS[1], ARGV[1])
+	   if not v then
+	      return nil
+	   end
 	   redis.call("HDEL", KEYS[1], ARGV[1])
 	   local rev = tostring(redis.call("HINCRBY", KEYS[1], "=rev", 1))
+	   redis.call("HSET", KEYS[1], "=kind", "del")
 	   local msg = struct.pack("ic0ic0", string.len(ARGV[1]), ARGV[1], string.len(rev), rev)
 	   redis.call("PUBLISH", KEYS[2], "del:" .. msg)
 	   return v
@@ -102,6 +110,7 @@ var (
 	   redis.call("HINCRBY", KEYS[1], ARGV[1], ARGV[2])
 	   local v = redis.call("HGET", KEYS[1], ARGV[1])
 	   local rev = tostring(redis.call("HINCRBY", KEYS[1], "=rev", 1))
+	   redis.call("HSET", KEYS[1], "=kind", "set")
 	   local msg = struct.pack("ic0ic0ic0", string.len(ARGV[1]), ARGV[1], string.len(v), v, string.len(rev), rev)
 	   redis.call("PUBLISH", KEYS[2], "set:" .. msg)
 	   return v
@@ -149,6 +158,7 @@ var (
 	   if #remaining == 0 then
 	      redis.call("HDEL", KEYS[1], key)
 	      local rev = tostring(redis.call("HINCRBY", KEYS[1], "=rev", 1))
+	      redis.call("HSET", KEYS[1], "=kind", "del")
 	      local msg = struct.pack("ic0ic0", string.len(key), key, string.len(rev), rev)
 	      redis.call("PUBLISH", KEYS[2], "del:" .. msg)
 	      return {"", 1}
@@ -157,6 +167,7 @@ var (
 	   local encoded = cjson.encode(remaining)
 	   redis.call("HSET", KEYS[1], key, encoded)
 	   local rev = tostring(redis.call("HINCRBY", KEYS[1], "=rev", 1))
+	   redis.call("HSET", KEYS[1], "=kind", "set")
 	   local msg = struct.pack("ic0ic0ic0", string.len(key), key, string.len(encoded), encoded, string.len(rev), rev)
 	   redis.call("PUBLISH", KEYS[2], "set:" .. msg)
 	   return {encoded, 1}
@@ -166,14 +177,16 @@ var (
 	luaReset = redis.NewScript(`
 	   local rev = redis.call("HINCRBY", KEYS[1], "=rev", 1)
 	   redis.call("DEL", KEYS[1])
-	   redis.call("HSET", KEYS[1], "=rev", rev)
+	   redis.call("HSET", KEYS[1], "=rev", rev, "=kind", "reset")
 	   redis.call("PUBLISH", KEYS[2], "reset:" .. tostring(rev))
 	`)
 
 	// luaDestroy is the Lua script used to delete the map entirely.
 	luaDestroy = redis.NewScript(`
+	   local rev = redis.call("HINCRBY", KEYS[1], "=rev", 1)
 	   redis.call("DEL", KEYS[1])
-	   redis.call("PUBLISH", KEYS[2], "reset:*")
+	   redis.call("HSET", KEYS[1], "=rev", rev, "=kind", "destroy")
+	   redis.call("PUBLISH", KEYS[2], "destroy:" .. tostring(rev))
 	`)
 
 	// luaSet is the Lua script used to set a key and return its previous value.  We
@@ -183,9 +196,16 @@ var (
 	   local v = redis.call("HGET", KEYS[1], ARGV[1])
 	   redis.call("HSET", KEYS[1], ARGV[1], ARGV[2])
 	   local rev = tostring(redis.call("HINCRBY", KEYS[1], "=rev", 1))
+	   redis.call("HSET", KEYS[1], "=kind", "set")
 	   local msg = struct.pack("ic0ic0ic0", string.len(ARGV[1]), ARGV[1], string.len(ARGV[2]), ARGV[2], string.len(rev), rev)
 	   redis.call("PUBLISH", KEYS[2], "set:" .. msg)
-	   return v
+	   local existed = 0
+	   local prev = ""
+	   if v then
+	      existed = 1
+	      prev = v
+	   end
+	   return {existed, prev, rev}
 	`)
 
 	// luaTestAndDel is the Lua script used to delete a key if it has a specific value.
@@ -194,6 +214,7 @@ var (
 	   if v == ARGV[2] then
 	      redis.call("HDEL", KEYS[1], ARGV[1])
 	      local rev = tostring(redis.call("HINCRBY", KEYS[1], "=rev", 1))
+	      redis.call("HSET", KEYS[1], "=kind", "del")
 	      local msg = struct.pack("ic0ic0", string.len(ARGV[1]), ARGV[1], string.len(rev), rev)
 	      redis.call("PUBLISH", KEYS[2], "del:" .. msg)
 	   end
@@ -213,7 +234,7 @@ var (
 	  end
 	  local rev = redis.call("HINCRBY", hash, "=rev", 1)
 	  redis.call("DEL", hash)
-	  redis.call("HSET", hash, "=rev", rev)
+	  redis.call("HSET", hash, "=rev", rev, "=kind", "reset")
 	  redis.call("PUBLISH", KEYS[2], "reset:" .. tostring(rev))
 	  return 1
 	`)
@@ -224,6 +245,7 @@ var (
 	   if v == ARGV[2] then
 	      redis.call("HSET", KEYS[1], ARGV[1], ARGV[3])
 	      local rev = tostring(redis.call("HINCRBY", KEYS[1], "=rev", 1))
+	      redis.call("HSET", KEYS[1], "=kind", "set")
 	      local msg = struct.pack("ic0ic0ic0", string.len(ARGV[1]), ARGV[1], string.len(ARGV[3]), ARGV[3], string.len(rev), rev)
 	      redis.call("PUBLISH", KEYS[2], "set:" .. msg)
 	   end
@@ -236,6 +258,7 @@ var (
         if not v then
             redis.call("HSET", KEYS[1], ARGV[1], ARGV[2])
             local rev = tostring(redis.call("HINCRBY", KEYS[1], "=rev", 1))
+            redis.call("HSET", KEYS[1], "=kind", "set")
             local msg = struct.pack("ic0ic0ic0", string.len(ARGV[1]), ARGV[1], string.len(ARGV[2]), ARGV[2], string.len(rev), rev)
             redis.call("PUBLISH", KEYS[2], "set:" .. msg)
             return 1  -- Successfully set the value

--- a/streaming/streams.go
+++ b/streaming/streams.go
@@ -8,6 +8,7 @@ import (
 
 	redis "github.com/redis/go-redis/v9"
 	"goa.design/pulse/pulse"
+	"goa.design/pulse/rmap"
 	"goa.design/pulse/streaming/options"
 )
 
@@ -186,36 +187,34 @@ func (s *Stream) Destroy(ctx context.Context) error {
 		s.logger.Error(err)
 		return err
 	}
-	// Destroy per-stream sink metadata map used by Pulse sinks to track consumers.
-	//
-	// Pulse sinks use an rmap keyed by "stream:<streamName>:sinks". The rmap stores
-	// its state in:
-	// - map:<name>:content (hash)
-	// - map:<name>:updates (pubsub channel)
-	//
-	// When a stream is explicitly destroyed, any sink metadata for that stream is
-	// also garbage. Cleaning it up here prevents leaks for short-lived streams
-	// (e.g., per-call result streams) that are destroyed explicitly.
-	//
-	// Note: we intentionally do not delete per-sink keepalive maps
-	// (sink:<sinkName>:keepalive) since those are shared across streams.
-	mapName := fmt.Sprintf("stream:%s:sinks", s.Name)
-	mapHashKey := fmt.Sprintf("map:%s:content", mapName)
-	mapChanKey := fmt.Sprintf("map:%s:updates", mapName)
-	if err := s.rdb.Del(ctx, mapHashKey).Err(); err != nil {
+	if err := s.destroyConsumersMap(ctx); err != nil {
 		err := fmt.Errorf("failed to destroy stream sink map: %w", err)
-		s.logger.Error(err)
-		return err
-	}
-	// Mirror rmap's destroy semantics so any in-flight subscribers can notice the
-	// map is gone.
-	if err := s.rdb.Publish(ctx, mapChanKey, "reset:*").Err(); err != nil {
-		err := fmt.Errorf("failed to publish sink map reset: %w", err)
 		s.logger.Error(err)
 		return err
 	}
 	s.logger.Info("stream deleted")
 	return nil
+}
+
+// destroyConsumersMap removes the per-stream sink membership map through the
+// rmap destroy protocol so reconnecting replicas observe the same revisioned
+// destroy semantics as every other replicated map.
+func (s *Stream) destroyConsumersMap(ctx context.Context) error {
+	mapName := consumersMapName(s)
+	mapKey := fmt.Sprintf("map:%s:content", mapName)
+	exists, err := s.rdb.Exists(ctx, mapKey).Result()
+	if err != nil {
+		return err
+	}
+	if exists == 0 {
+		return nil
+	}
+	consumers, err := rmap.Join(ctx, mapName, s.rdb, consumersMapOptions(s, s.rootLogger)...)
+	if err != nil {
+		return err
+	}
+	defer consumers.Close()
+	return consumers.Destroy(ctx)
 }
 
 // redisKeyRegex is a regular expression that matches valid Redis keys.

--- a/streaming/streams_test.go
+++ b/streaming/streams_test.go
@@ -1,6 +1,7 @@
 package streaming
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -121,7 +122,7 @@ func TestStreamTTLSliding(t *testing.T) {
 	assert.NoError(t, s.Destroy(ctx))
 }
 
-func TestStreamDestroyDeletesSinkMap(t *testing.T) {
+func TestStreamDestroyUsesRMapDestroyProtocol(t *testing.T) {
 	rdb := ptesting.NewRedisClient(t)
 	defer ptesting.CleanupRedis(t, rdb, false, "")
 	ctx := ptesting.NewTestContext(t)
@@ -139,9 +140,12 @@ func TestStreamDestroyDeletesSinkMap(t *testing.T) {
 	assert.EqualValues(t, 1, exists)
 
 	assert.NoError(t, s.Destroy(ctx))
-	exists, err = rdb.Exists(ctx, mapKey).Result()
+	content, err := rdb.HGetAll(ctx, mapKey).Result()
 	assert.NoError(t, err)
-	assert.EqualValues(t, 0, exists)
+	assert.Len(t, content, 2)
+	assert.Equal(t, "destroy", content["=kind"])
+	_, err = strconv.ParseUint(content["=rev"], 10, 64)
+	assert.NoError(t, err)
 }
 
 func TestRemove(t *testing.T) {

--- a/testing/redis.go
+++ b/testing/redis.go
@@ -64,6 +64,11 @@ func CleanupRedis(t *testing.T, rdb *redis.Client, checkClean bool, testName str
 					// Sinks content is cleaned up asynchronously, so ignore it
 					continue
 				}
+				if isDestroyTombstone(ctx, rdb, k) {
+					// Destroy tombstones are intentional rmap protocol state used so
+					// reconnecting replicas can order the next generation correctly.
+					continue
+				}
 				if streamRegexp.MatchString(k) {
 					// Node streams are cleaned up asynchronously, so ignore them
 					continue
@@ -77,4 +82,22 @@ func CleanupRedis(t *testing.T, rdb *redis.Client, checkClean bool, testName str
 		require.NoError(t, keysErr)
 	}
 	assert.NoError(t, rdb.FlushDB(ctx).Err())
+}
+
+func isDestroyTombstone(ctx context.Context, rdb *redis.Client, key string) bool {
+	if !strings.HasPrefix(key, "map:") || !strings.HasSuffix(key, ":content") {
+		return false
+	}
+	content, err := rdb.HGetAll(ctx, key).Result()
+	if err != nil {
+		return false
+	}
+	if len(content) != 2 {
+		return false
+	}
+	if content["=kind"] != "destroy" {
+		return false
+	}
+	_, ok := content["=rev"]
+	return ok
 }


### PR DESCRIPTION
## Summary
- order replicated-map writes by committed revision so destroy/reconnect recovery and `SetAndWait` acknowledgements stay consistent under concurrent updates
- route stream sink cleanup through the rmap destroy protocol and preserve destroy tombstones as intentional protocol state in tests
- retry distributed ticker advances after transient map write failures and add the repo `AGENTS.md` guidance in-tree

## Test plan
- [ ] Run `go test ./rmap ./streaming ./pool` in a Redis-backed environment
- [ ] Verify `rmap.Destroy()` and reconnect keep revision ordering intact across replica resync
- [ ] Verify a transient ticker map write failure rearms the local timer and resumes ticking without unrelated map traffic

## Notes
- I reviewed the existing local commit `3a2cc7f` before opening this PR and did not find a blocker that required changes before shipping.
- Local `go test ./pool` currently fails during Redis test setup with `EOF`, so I did not claim a clean package test run in this environment.