### PR TITLE
Fix duplicate pool job dispatch across replicas

### DIFF
--- a/pool/node.go
+++ b/pool/node.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -352,61 +353,23 @@ func (node *Node) PoolWorkers() []*Worker {
 // The method blocks until one of the above conditions is met.
 func (node *Node) DispatchJob(ctx context.Context, key string, payload []byte) error {
 	job := marshalJob(&Job{Key: key, Payload: payload, CreatedAt: time.Now(), NodeID: node.ID})
-	return node.dispatchJob(ctx, key, job, false)
+	return node.dispatchJob(ctx, key, job)
 }
 
-func (node *Node) dispatchJob(ctx context.Context, key string, job []byte, requeue bool) error {
-	// Allow internal requeue operations to proceed while the node is closing.
-	// External callers use DispatchJob which passes requeue=false and should be
-	// rejected once Close begins.
-	if node.IsClosed() && !requeue {
+func (node *Node) dispatchJob(ctx context.Context, key string, job []byte) error {
+	if node.IsClosed() {
 		return fmt.Errorf("DispatchJob: pool %q is closed", node.PoolName)
 	}
 
-	if !requeue {
-		// Check if job already exists in job payloads map
-		if _, exists := node.jobPayloadMap.Get(key); exists {
-			node.logger.Info("DispatchJob: job already exists", "key", key)
-			return fmt.Errorf("%w: job %q", ErrJobExists, key)
-		}
-	}
-
-	// Check if there's a pending dispatch for this job
-	pendingTS, exists := node.jobPendingMap.Get(key)
-	if exists {
-		if node.isWithinTTL(pendingTS, 0) {
-			node.logger.Info("DispatchJob: job already dispatched", "key", key)
-			return fmt.Errorf("%w: job %q is already dispatched", ErrJobExists, key)
-		}
-	}
-
-	// Set pending timestamp using atomic operation
-	pendingUntil := time.Now().Add(2 * node.ackGracePeriod).UnixNano()
-	newTS := strconv.FormatInt(pendingUntil, 10)
-	if exists {
-		current, err := node.jobPendingMap.TestAndSet(ctx, key, pendingTS, newTS)
-		if err != nil {
-			return fmt.Errorf("DispatchJob: failed to set pending timestamp for job %q: %w", key, err)
-		}
-		if current != pendingTS {
-			return fmt.Errorf("%w: job %q is already being dispatched", ErrJobExists, key)
-		}
-	} else {
-		ok, err := node.jobPendingMap.SetIfNotExists(ctx, key, newTS)
-		if err != nil {
-			return fmt.Errorf("DispatchJob: failed to set initial pending timestamp for job %q: %w", key, err)
-		}
-		if !ok {
-			return fmt.Errorf("%w: job %q is already being dispatched", ErrJobExists, key)
-		}
+	pendingTS, err := node.claimDispatch(ctx, key)
+	if err != nil {
+		return err
 	}
 
 	eventID, err := node.poolStream.Add(ctx, evStartJob, job)
 	if err != nil {
 		// Clean up pending entry on failure
-		if _, err := node.jobPendingMap.Delete(ctx, key); err != nil {
-			node.logger.Error(fmt.Errorf("DispatchJob: failed to clean up pending entry for job %q: %w", key, err))
-		}
+		node.releaseDispatchPending(key, pendingTS)
 		return fmt.Errorf("DispatchJob: failed to add job to stream %q: %w", node.poolStream.Name, err)
 	}
 
@@ -428,9 +391,7 @@ func (node *Node) dispatchJob(ctx context.Context, key string, job []byte, reque
 	close(cherr)
 
 	// Clean up pending entry
-	if _, err := node.jobPendingMap.Delete(ctx, key); err != nil {
-		node.logger.Error(fmt.Errorf("DispatchJob: failed to clean up pending entry for job %q: %w", key, err))
-	}
+	node.releaseDispatchPending(key, pendingTS)
 
 	if err != nil {
 		node.logger.Error(fmt.Errorf("DispatchJob: failed to dispatch job: %w", err), "key", key)
@@ -439,6 +400,78 @@ func (node *Node) dispatchJob(ctx context.Context, key string, job []byte, reque
 
 	node.logger.Info("dispatched", "key", key)
 	return nil
+}
+
+// claimDispatch atomically decides whether a job key may be dispatched. Redis is
+// the source of truth for both states that matter to singleton admission: a
+// durable payload means the job is already running, and a pending guard means a
+// worker is currently starting it.
+func (node *Node) claimDispatch(ctx context.Context, key string) (string, error) {
+	if key == "" {
+		return "", fmt.Errorf("DispatchJob: job key cannot be empty")
+	}
+	if strings.Contains(key, "=") {
+		return "", fmt.Errorf("DispatchJob: job key %q cannot contain '='", key)
+	}
+	now := time.Now()
+	pendingUntil := strconv.FormatInt(now.Add(2*node.ackGracePeriod).UnixNano(), 10)
+	raw, err := luaClaimDispatch.Run(ctx, node.rdb, []string{
+		rmapContentKey(jobPayloadMapName(node.PoolName)),
+		rmapContentKey(jobPendingMapName(node.PoolName)),
+		rmapUpdateChannel(jobPendingMapName(node.PoolName)),
+	}, key, strconv.FormatInt(now.UnixNano(), 10), pendingUntil).Result()
+	if err != nil {
+		return "", fmt.Errorf("DispatchJob: failed to claim job %q: %w", key, err)
+	}
+	status, value, err := parseDispatchClaim(raw)
+	if err != nil {
+		return "", fmt.Errorf("DispatchJob: failed to parse claim result for job %q: %w", key, err)
+	}
+	switch status {
+	case dispatchClaimed:
+		return value, nil
+	case dispatchAlreadyPending:
+		node.logger.Info("DispatchJob: job already dispatched", "key", key)
+		return "", fmt.Errorf("%w: job %q is already dispatched", ErrJobExists, key)
+	case dispatchAlreadyRunning:
+		node.logger.Info("DispatchJob: job already exists", "key", key)
+		return "", fmt.Errorf("%w: job %q", ErrJobExists, key)
+	case dispatchMalformedPending:
+		return "", fmt.Errorf("DispatchJob: malformed pending guard for job %q: %q", key, value)
+	default:
+		return "", fmt.Errorf("DispatchJob: unexpected claim status %d for job %q", status, key)
+	}
+}
+
+// releaseDispatchPending clears the pending guard only if this dispatch still
+// owns it. Dispatch callers can time out while another node later claims a
+// stale pending key, so unconditional deletion would erase a newer guard.
+func (node *Node) releaseDispatchPending(key, pendingTS string) {
+	if _, err := luaReleaseDispatch.Run(context.Background(), node.rdb, []string{
+		rmapContentKey(jobPendingMapName(node.PoolName)),
+		rmapUpdateChannel(jobPendingMapName(node.PoolName)),
+	}, key, pendingTS).Result(); err != nil {
+		node.logger.Error(fmt.Errorf("DispatchJob: failed to clean up pending entry for job %q: %w", key, err))
+	}
+}
+
+// parseDispatchClaim decodes the Lua admission result into its status code and
+// payload. The script owns the result schema so malformed data is a programming
+// error, not a recoverable distributed state.
+func parseDispatchClaim(raw any) (int64, string, error) {
+	values, ok := raw.([]any)
+	if !ok || len(values) != 2 {
+		return 0, "", fmt.Errorf("invalid claim result %T", raw)
+	}
+	status, ok := values[0].(int64)
+	if !ok {
+		return 0, "", fmt.Errorf("invalid claim status %T", values[0])
+	}
+	value, ok := values[1].(string)
+	if !ok {
+		return 0, "", fmt.Errorf("invalid claim value %T", values[1])
+	}
+	return status, value, nil
 }
 
 // StopJob stops the job with the given key.
@@ -1127,6 +1160,10 @@ func (node *Node) processInactiveJobs(ctx context.Context) {
 // An entry is considered stale if its timestamp has expired.
 func (node *Node) cleanupStalePendingJobs(ctx context.Context) {
 	for key, pendingTS := range node.jobPendingMap.Map() {
+		if _, err := strconv.ParseInt(pendingTS, 10, 64); err != nil {
+			node.logger.Error(fmt.Errorf("cleanupStalePendingJobs: malformed pending timestamp for job %q: %w", key, err))
+			continue
+		}
 		if node.isWithinTTL(pendingTS, 0) {
 			continue
 		}
@@ -1484,6 +1521,16 @@ func jobPendingMapName(poolName string) string {
 // job payloads by job key.
 func jobPayloadMapName(pool string) string {
 	return fmt.Sprintf("%s:job-payloads", pool)
+}
+
+// rmapContentKey returns the Redis hash key used by an rmap.
+func rmapContentKey(name string) string {
+	return fmt.Sprintf("map:%s:content", name)
+}
+
+// rmapUpdateChannel returns the Redis pubsub channel used by an rmap.
+func rmapUpdateChannel(name string) string {
+	return fmt.Sprintf("map:%s:updates", name)
 }
 
 // tickerMapName returns the name of the replicated map used to store ticker

--- a/pool/node_jobloss_test.go
+++ b/pool/node_jobloss_test.go
@@ -44,7 +44,7 @@ func TestJobLossDuringConcurrentWorkerCleanup(t *testing.T) {
 		WithWorkerTTL(200 * time.Millisecond),
 		WithWorkerShutdownTTL(200 * time.Millisecond),
 		WithJobSinkBlockDuration(50 * time.Millisecond),
-		WithAckGracePeriod(200 * time.Millisecond),
+		WithAckGracePeriod(300 * time.Millisecond),
 		// Keep logs quiet so failures are easy to see (and tool output isn't truncated).
 		WithLogger(pulse.NoopLogger()),
 	}
@@ -172,17 +172,16 @@ func TestJobLossDuringConcurrentWorkerCleanup(t *testing.T) {
 	}
 
 phase4:
-	// Give background cleanup/rebalancing time to progress.
-	time.Sleep(1 * time.Second)
-
-	// Drain node3 starts for a bounded time and count unique jobs that landed there.
+	// Drain node3 starts until every job lands there or the recovery deadline
+	// expires. The test stresses background cleanup, so the correctness condition
+	// is eventual recovery rather than a fixed short sleep.
 	jobsOnNode3 := make(map[string]bool)
-	drainTimeout := time.After(2 * time.Second)
-	for {
+	recoveryTimeout := time.After(10 * time.Second)
+	for len(jobsOnNode3) < numJobs {
 		select {
 		case key := <-jobRequeuedToNode3:
 			jobsOnNode3[key] = true
-		case <-drainTimeout:
+		case <-recoveryTimeout:
 			goto done
 		}
 	}

--- a/pool/node_test.go
+++ b/pool/node_test.go
@@ -319,6 +319,142 @@ func TestDispatchJobRaceCondition(t *testing.T) {
 		assert.True(t, errors.Is(err, ErrJobExists), "Expected ErrJobExists, got: %v", err)
 	})
 
+	t.Run("claim rejects active pending job from redis", func(t *testing.T) {
+		jobKey := "active-redis-pending-job"
+		pendingHash := rmapContentKey(jobPendingMapName(testName))
+		pendingUntil := strconv.FormatInt(time.Now().Add(time.Hour).UnixNano(), 10)
+		require.NoError(t, rdb.HSet(ctx, pendingHash, jobKey, pendingUntil).Err())
+		_, localExists := node2.jobPendingMap.Get(jobKey)
+		require.False(t, localExists)
+
+		pendingTS, err := node2.claimDispatch(ctx, jobKey)
+		require.Empty(t, pendingTS)
+		require.True(t, errors.Is(err, ErrJobExists), "Expected ErrJobExists, got: %v", err)
+
+		stored, err := rdb.HGet(ctx, pendingHash, jobKey).Result()
+		require.NoError(t, err)
+		require.Equal(t, pendingUntil, stored)
+	})
+
+	t.Run("claim replaces stale pending job and publishes it", func(t *testing.T) {
+		jobKey := "stale-redis-pending-job"
+		pendingHash := rmapContentKey(jobPendingMapName(testName))
+		staleUntil := strconv.FormatInt(time.Now().Add(-time.Hour).UnixNano(), 10)
+		require.NoError(t, rdb.HSet(ctx, pendingHash, jobKey, staleUntil).Err())
+
+		pendingTS, err := node2.claimDispatch(ctx, jobKey)
+		require.NoError(t, err)
+		require.NotEmpty(t, pendingTS)
+
+		stored, err := rdb.HGet(ctx, pendingHash, jobKey).Result()
+		require.NoError(t, err)
+		require.Equal(t, pendingTS, stored)
+		require.Eventually(t, func() bool {
+			local, exists := node2.jobPendingMap.Get(jobKey)
+			return exists && local == pendingTS
+		}, max, delay)
+		node2.releaseDispatchPending(jobKey, pendingTS)
+	})
+
+	t.Run("claim rejects malformed pending job", func(t *testing.T) {
+		jobKey := "malformed-redis-pending-job"
+		pendingHash := rmapContentKey(jobPendingMapName(testName))
+		const malformedPending = "not-a-timestamp"
+		require.NoError(t, rdb.HSet(ctx, pendingHash, jobKey, malformedPending).Err())
+
+		pendingTS, err := node2.claimDispatch(ctx, jobKey)
+		require.Empty(t, pendingTS)
+		require.Error(t, err)
+		require.False(t, errors.Is(err, ErrJobExists))
+
+		stored, err := rdb.HGet(ctx, pendingHash, jobKey).Result()
+		require.NoError(t, err)
+		require.Equal(t, malformedPending, stored)
+	})
+
+	t.Run("release only removes owned pending guard", func(t *testing.T) {
+		jobKey := "owned-pending-release-job"
+		pendingHash := rmapContentKey(jobPendingMapName(testName))
+		pendingTS, err := node2.claimDispatch(ctx, jobKey)
+		require.NoError(t, err)
+		require.NotEmpty(t, pendingTS)
+		require.Eventually(t, func() bool {
+			local, exists := node2.jobPendingMap.Get(jobKey)
+			return exists && local == pendingTS
+		}, max, delay)
+
+		node2.releaseDispatchPending(jobKey, "not-"+pendingTS)
+		stored, err := rdb.HGet(ctx, pendingHash, jobKey).Result()
+		require.NoError(t, err)
+		require.Equal(t, pendingTS, stored)
+
+		node2.releaseDispatchPending(jobKey, pendingTS)
+		pendingExists, err := rdb.HExists(ctx, pendingHash, jobKey).Result()
+		require.NoError(t, err)
+		require.False(t, pendingExists)
+		require.Eventually(t, func() bool {
+			_, exists := node2.jobPendingMap.Get(jobKey)
+			return !exists
+		}, max, delay)
+	})
+
+	t.Run("concurrent atomic claims admit one dispatcher", func(t *testing.T) {
+		jobKey := "concurrent-claim-job"
+		errCh := make(chan error, 20)
+		pendingCh := make(chan string, 20)
+		var wg sync.WaitGroup
+		for i := 0; i < 20; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				pendingTS, err := node2.claimDispatch(ctx, jobKey)
+				if err == nil {
+					pendingCh <- pendingTS
+				}
+				errCh <- err
+			}()
+		}
+		wg.Wait()
+		close(errCh)
+		close(pendingCh)
+
+		successCount := 0
+		errorCount := 0
+		for err := range errCh {
+			if err == nil {
+				successCount++
+				continue
+			}
+			if errors.Is(err, ErrJobExists) {
+				errorCount++
+				continue
+			}
+			t.Errorf("unexpected error: %v", err)
+		}
+		require.Equal(t, 1, successCount)
+		require.Equal(t, 19, errorCount)
+		node2.releaseDispatchPending(jobKey, <-pendingCh)
+	})
+
+	t.Run("dispatch checks redis when local payload replica is stale", func(t *testing.T) {
+		jobKey := "stale-local-payload-job"
+		payload := []byte("test payload")
+		payloadHash := rmapContentKey(jobPayloadMapName(testName))
+		pendingHash := rmapContentKey(jobPendingMapName(testName))
+
+		// Simulate the production race: Redis already has the live job payload,
+		// but this node's local rmap replica has not applied that update yet.
+		require.NoError(t, rdb.HSet(ctx, payloadHash, jobKey, string(payload)).Err())
+		_, localExists := node2.jobPayloadMap.Get(jobKey)
+		require.False(t, localExists)
+
+		err := node2.DispatchJob(ctx, jobKey, []byte("new payload"))
+		assert.True(t, errors.Is(err, ErrJobExists), "Expected ErrJobExists, got: %v", err)
+		pendingExists, err := rdb.HExists(ctx, pendingHash, jobKey).Result()
+		require.NoError(t, err)
+		require.False(t, pendingExists)
+	})
+
 	t.Run("dispatch after pending job times out succeeds", func(t *testing.T) {
 		jobKey := "timeout-job"
 		payload := []byte("test payload")
@@ -352,7 +488,7 @@ func TestDispatchJobRaceCondition(t *testing.T) {
 		}, max, delay, "Pending entry should be cleaned up after successful dispatch")
 	})
 
-	t.Run("dispatch with invalid pending timestamp", func(t *testing.T) {
+	t.Run("dispatch rejects invalid pending timestamp", func(t *testing.T) {
 		jobKey := "invalid-timestamp-job"
 		payload := []byte("test payload")
 
@@ -360,9 +496,13 @@ func TestDispatchJobRaceCondition(t *testing.T) {
 		_, err := node1.jobPendingMap.SetAndWait(ctx, jobKey, "invalid-timestamp")
 		require.NoError(t, err, "Failed to set invalid pending timestamp")
 
-		// Dispatch should succeed (invalid timestamps are logged and ignored)
 		err = node1.DispatchJob(ctx, jobKey, payload)
-		assert.NoError(t, err, "Dispatch should succeed with invalid pending timestamp")
+		require.Error(t, err)
+		require.False(t, errors.Is(err, ErrJobExists))
+		require.Contains(t, err.Error(), "malformed pending guard")
+		stored, err := rdb.HGet(ctx, rmapContentKey(jobPendingMapName(testName)), jobKey).Result()
+		require.NoError(t, err)
+		require.Equal(t, "invalid-timestamp", stored)
 	})
 
 	// Keep this test last, it destroys the stream

--- a/pool/scripts.go
+++ b/pool/scripts.go
@@ -1,0 +1,75 @@
+// Package pool keeps its cross-map coordination scripts close to the pool
+// admission code. These scripts preserve the rmap notification contract while
+// making singleton job admission one atomic Redis operation.
+package pool
+
+import redis "github.com/redis/go-redis/v9"
+
+const (
+	dispatchClaimed int64 = iota + 1
+	dispatchAlreadyPending
+	dispatchAlreadyRunning
+	dispatchMalformedPending
+)
+
+var (
+	// luaClaimDispatch atomically admits a new external dispatch. A job key may
+	// be claimed only when no durable payload exists and no active pending guard
+	// exists. Stale pending guards are replaced by the caller's new guard and
+	// published through the pending rmap channel; malformed guards are rejected
+	// because they indicate corrupted coordination state.
+	luaClaimDispatch = redis.NewScript(`
+local payload = redis.call("HGET", KEYS[1], ARGV[1])
+if payload then
+   return {3, ""}
+end
+
+local function all_digits(value)
+   return string.match(value, "^%d+$") ~= nil
+end
+
+local function active_until(value, now)
+   if not all_digits(value) then
+      return false
+   end
+   if string.len(value) ~= string.len(now) then
+      return string.len(value) > string.len(now)
+   end
+   return value >= now
+end
+
+local pending = redis.call("HGET", KEYS[2], ARGV[1])
+if pending then
+   if not all_digits(pending) then
+      return {4, pending}
+   end
+   if active_until(pending, ARGV[2]) then
+      return {2, pending}
+   end
+end
+
+redis.call("HSET", KEYS[2], ARGV[1], ARGV[3])
+local rev = tostring(redis.call("HINCRBY", KEYS[2], "=rev", 1))
+redis.call("HSET", KEYS[2], "=kind", "set")
+local msg = struct.pack("ic0ic0ic0", string.len(ARGV[1]), ARGV[1], string.len(ARGV[3]), ARGV[3], string.len(rev), rev)
+redis.call("PUBLISH", KEYS[3], "set:" .. msg)
+return {1, ARGV[3]}
+`)
+
+	// luaReleaseDispatch removes the pending guard only if it still belongs to
+	// this dispatch attempt. It publishes a delete notification so rmap replicas
+	// converge without relying on a later cleanup sweep.
+	luaReleaseDispatch = redis.NewScript(`
+local pending = redis.call("HGET", KEYS[1], ARGV[1])
+if pending ~= ARGV[2] then
+   return 0
+end
+
+redis.call("HDEL", KEYS[1], ARGV[1])
+local rev = tostring(redis.call("HINCRBY", KEYS[1], "=rev", 1))
+redis.call("HSET", KEYS[1], "=kind", "del")
+local msg = struct.pack("ic0ic0", string.len(ARGV[1]), ARGV[1], string.len(rev), rev)
+redis.call("PUBLISH", KEYS[2], "del:" .. msg)
+return 1
+`)
+)


### PR DESCRIPTION
## Summary
- Fixes a race where two Pulse pool replicas could start the same job key at the same time.
- Moves job dispatch admission into one Redis-side claim that atomically checks both "job already running" and "job currently starting" state.
- Makes pending dispatch cleanup owner-aware so one timed-out dispatcher cannot delete another dispatcher's guard.

## What was happening
Pulse uses job keys as singleton identifiers: if a job with key `processDispatch` is already running, another `DispatchJob` call with the same key should return `ErrJobExists` instead of starting a duplicate.

Before this change, that guarantee depended partly on local replicated-map state. A restarted or lagging replica could briefly miss the running-job payload in its local cache. If the original dispatcher had already removed the pending-start entry, the lagging replica could claim the key and enqueue the same job again. In a multi-replica deployment this could show up as duplicate singleton jobs, for example two `processDispatch` jobs spread across two pod replicas.

## Fix
Dispatch admission is now one Redis Lua operation. For a given job key, Redis atomically decides:
- reject if the durable job payload already exists, because the job is running;
- reject if a non-expired pending dispatch guard exists, because a worker is starting it;
- otherwise create the pending guard and allow the dispatch to proceed.

The pending guard is also released with an owner check. If an older dispatch times out locally, it cannot remove a newer dispatch's guard.

Malformed pending guards now fail closed instead of being treated as stale. That avoids hiding corrupted coordination state behind another dispatch attempt.

## Test plan
- `go test ./pool -run '^TestJobLossDuringConcurrentWorkerCleanup$' -count=10 -timeout 120s`
- `go test ./pool -count=1 -timeout 120s`
- `go test -p 1 ./... -count=1 -timeout 120s`
- `go test -race ./pool -count=1 -timeout 120s`

Note: the repository-wide Redis-backed suite should run with `-p 1` because packages share the same test Redis instance and some tests flush it.