### PR TITLE
streaming: prevent reader Close from deadlocking on a fatal read error

### DIFF
--- a/streaming/reader.go
+++ b/streaming/reader.go
@@ -55,10 +55,6 @@ type (
 		closing bool
 		// eventFilter is the event filter if any.
 		eventFilter eventFilterFunc
-		// xreadFn fetches the next batch of events from Redis. It defaults
-		// to (*Reader).xread and is only overridden in tests to simulate
-		// read errors.
-		xreadFn func(context.Context) ([]redis.XStream, error)
 		// logger is the logger used by the reader.
 		logger pulse.Logger
 		// rdb is the redis connection.
@@ -221,16 +217,17 @@ func (r *Reader) start() {
 	})
 }
 
+// xreadFn fetches the next batch of events for a reader. It is a package
+// variable (rather than a struct field) so tests can simulate read errors
+// without polluting Reader; it defaults to (*Reader).xread.
+var xreadFn = (*Reader).xread
+
 // read reads events from the streams and sends them to the reader channel.
 func (r *Reader) read() {
 	ctx := context.Background()
 	defer r.cleanup()
-	readEvents := r.xread
-	if r.xreadFn != nil {
-		readEvents = r.xreadFn
-	}
 	for {
-		streamsEvents, err := readEvents(ctx)
+		streamsEvents, err := xreadFn(r, ctx)
 		if r.isClosing() {
 			return
 		}

--- a/streaming/reader.go
+++ b/streaming/reader.go
@@ -55,6 +55,10 @@ type (
 		closing bool
 		// eventFilter is the event filter if any.
 		eventFilter eventFilterFunc
+		// xreadFn fetches the next batch of events from Redis. It defaults
+		// to (*Reader).xread and is only overridden in tests to simulate
+		// read errors.
+		xreadFn func(context.Context) ([]redis.XStream, error)
 		// logger is the logger used by the reader.
 		logger pulse.Logger
 		// rdb is the redis connection.
@@ -221,15 +225,23 @@ func (r *Reader) start() {
 func (r *Reader) read() {
 	ctx := context.Background()
 	defer r.cleanup()
+	readEvents := r.xread
+	if r.xreadFn != nil {
+		readEvents = r.xreadFn
+	}
 	for {
-		streamsEvents, err := r.xread(ctx)
+		streamsEvents, err := readEvents(ctx)
 		if r.isClosing() {
 			return
 		}
 		if err != nil {
 			if err := handleReadError(err, r.logger); err != nil {
 				r.logger.Error(fmt.Errorf("fatal error while reading events: %w, stopping", err))
-				r.Close()
+				// Close waits on this goroutine via wait.Wait, so calling it
+				// synchronously here would deadlock and leak the reader and its
+				// Redis connection. Trigger the shutdown asynchronously and let
+				// this goroutine return so cleanup can release the wait group.
+				pulse.Go(r.logger, r.Close)
 				return
 			}
 			continue

--- a/streaming/reader_test.go
+++ b/streaming/reader_test.go
@@ -1,6 +1,8 @@
 package streaming
 
 import (
+	"context"
+	"fmt"
 	"strconv"
 	"strings"
 	"testing"
@@ -122,6 +124,30 @@ func TestCleanupReader(t *testing.T) {
 	assert.Equal(t, rdb.Exists(ctx, s.key).Val(), int64(1))
 	assert.NoError(t, s.Destroy(ctx))
 	assert.Eventually(t, func() bool { return rdb.Exists(ctx, s.key).Val() == 0 }, max, delay)
+}
+
+func TestReaderCloseOnFatalReadError(t *testing.T) {
+	testName := strings.Replace(t.Name(), "/", "_", -1)
+	rdb := ptesting.NewRedisClient(t)
+	defer ptesting.CleanupRedis(t, rdb, true, testName)
+	ctx := ptesting.NewTestContext(t)
+	s, err := NewStream(testName, rdb, options.WithStreamLogger(pulse.ClueLogger(ctx)))
+	require.NoError(t, err)
+	reader, err := s.NewReader(ctx, options.WithReaderBlockDuration(testBlockDuration))
+	require.NoError(t, err)
+
+	// Simulate a fatal read error (e.g. the underlying stream key being
+	// destroyed) before the read goroutine starts. The read loop reacts to a
+	// fatal error by closing the reader; because Close waits on the read
+	// goroutine, it must run asynchronously or it would deadlock and leak the
+	// reader and its Redis connection.
+	reader.xreadFn = func(context.Context) ([]redis.XStream, error) {
+		return nil, fmt.Errorf("stream key no longer exists")
+	}
+	reader.Subscribe()
+
+	require.Eventually(t, func() bool { return reader.IsClosed() }, max, delay,
+		"reader did not close after a fatal read error (Close likely deadlocked on its own read goroutine)")
 }
 
 func TestAddReaderStream(t *testing.T) {

--- a/streaming/reader_test.go
+++ b/streaming/reader_test.go
@@ -133,17 +133,18 @@ func TestReaderCloseOnFatalReadError(t *testing.T) {
 	ctx := ptesting.NewTestContext(t)
 	s, err := NewStream(testName, rdb, options.WithStreamLogger(pulse.ClueLogger(ctx)))
 	require.NoError(t, err)
-	reader, err := s.NewReader(ctx, options.WithReaderBlockDuration(testBlockDuration))
-	require.NoError(t, err)
-
 	// Simulate a fatal read error (e.g. the underlying stream key being
 	// destroyed) before the read goroutine starts. The read loop reacts to a
 	// fatal error by closing the reader; because Close waits on the read
 	// goroutine, it must run asynchronously or it would deadlock and leak the
 	// reader and its Redis connection.
-	reader.xreadFn = func(context.Context) ([]redis.XStream, error) {
+	defer func(orig func(*Reader, context.Context) ([]redis.XStream, error)) { xreadFn = orig }(xreadFn)
+	xreadFn = func(*Reader, context.Context) ([]redis.XStream, error) {
 		return nil, fmt.Errorf("stream key no longer exists")
 	}
+
+	reader, err := s.NewReader(ctx, options.WithReaderBlockDuration(testBlockDuration))
+	require.NoError(t, err)
 	reader.Subscribe()
 
 	require.Eventually(t, func() bool { return reader.IsClosed() }, max, delay,


### PR DESCRIPTION
## Summary
Follow-up to #77. That PR fixed `Close` deadlocking on a stalled subscriber; this fixes a sibling deadlock in the same area that I spotted while reviewing it.

On a fatal read error — `handleReadError` returns the error when Redis reports the stream key no longer exists — the reader's read loop calls `Close()` on itself:

```go
if err := handleReadError(err, r.logger); err != nil {
    r.logger.Error(...)
    r.Close()
    return
}
```

But `Close` does `r.wait.Wait()`, which waits for the read goroutine to run its deferred `cleanup()` (`wait.Done()`). Since that goroutine is the one blocked inside `Close`, it deadlocks: the read goroutine and its Redis connection leak, and any external `Close()` blocks forever too. Same goroutine + connection leak as #77, different trigger.

## Fix
Trigger the shutdown asynchronously (`pulse.Go(r.logger, r.Close)`) and let the read goroutine return so `cleanup` releases the wait group. `Close` is already idempotent via `sync.Once` (from #77), so this is safe alongside a concurrent external `Close`.

Only `Reader` is affected — `Sink.read` logs and continues on read errors rather than closing itself.

## Note on the test
The fatal path is only reached when Redis returns `"stream key no longer exists"`, which it does not emit deterministically for a blocking `XREAD` (deleting the key doesn't unblock the call, so a Redis-driven test would be timing-dependent). To get a deterministic regression test that exercises the real `read()` loop, I added a small package-level `xreadFn` seam that defaults to `(*Reader).xread` and is only overridden in tests to inject the fatal error. Happy to drop it if you'd rather not carry the seam.

## Test plan
- `go test -race ./streaming -run TestReaderCloseOnFatalReadError -count=10` — new regression test; hangs on pre-fix code (verified by reverting the fix), passes here.
- `go test -race ./streaming -count=1`