### PR TITLE
streaming: recover consumer groups losslessly after Redis state loss

### DIFF
--- a/pool/node_test.go
+++ b/pool/node_test.go
@@ -587,12 +587,16 @@ func TestDispatchJobRaceCondition(t *testing.T) {
 		jobKey := "cleanup-job"
 		payload := []byte("test payload")
 
-		// Corrupt the pool stream to force dispatch failure
-		err := rdb.Del(ctx, "pulse:stream:"+poolStreamName(node1.PoolName)).Err()
-		require.NoError(t, err, "Failed to delete pool stream")
+		// Replace the Redis stream with a string so XADD fails. Deleting the
+		// stream no longer forces this path because the pool sink now
+		// recovers externally deleted consumer groups.
+		streamKey := "pulse:stream:" + poolStreamName(node1.PoolName)
+		require.NoError(t, rdb.Del(ctx, streamKey).Err())
+		require.NoError(t, rdb.Set(ctx, streamKey, "wrong-type", 0).Err())
+		defer func() { require.NoError(t, rdb.Del(ctx, streamKey).Err()) }()
 
 		// Attempt dispatch (should fail)
-		err = node1.DispatchJob(ctx, jobKey, payload)
+		err := node1.DispatchJob(ctx, jobKey, payload)
 		require.Error(t, err, "Expected dispatch to fail")
 
 		// Verify pending entry was cleaned up

--- a/streaming/README.md
+++ b/streaming/README.md
@@ -149,6 +149,37 @@ flowchart LR
     linkStyle 6 stroke:#DDDDDD,color:#DDDDDD,stroke-width:3px;
 ```
 
+## Failure recovery
+
+Sinks are designed to survive Redis state loss without dropping acknowledged
+work or losing unacknowledged events:
+
+- **Lossless consumer group recovery**: each sink keeps a durable *recovery
+  cursor* per stream (the highest event ID known to be fully acknowledged),
+  advanced atomically with every acknowledgment from the exact pending entry
+  list state. When the Redis consumer group disappears (e.g. `XGROUP DESTROY`
+  or key loss) the sink recreates the group at the recovery cursor — never at
+  `$` — so every unacknowledged event is redelivered and no acknowledged event
+  is replayed. Events acknowledged out of order ahead of the cursor may be
+  redelivered after recovery (at-least-once).
+- **Jittered retries**: transient Redis failures in readers and sinks are
+  retried with exponential backoff jittered between half and full of the
+  current delay so replicas do not retry in lockstep.
+- **Prompt shutdown**: `Sink.Close` cancels all sink-owned Redis I/O,
+  including blocked reads and recovery in progress. `AddStream` and
+  `RemoveStream` return `ErrSinkClosed` after `Close`.
+- **Fenced maintenance**: idle-message claiming (`XAUTOCLAIM`) and stale
+  consumer cleanup run under a per-stream lease fenced with Redis time; lease
+  renewal and the guarded mutation are one atomic operation so a stale sink
+  instance can never mutate the pending entry list after another instance
+  takes over.
+- **Destroy fence**: `Stream.Destroy` atomically deletes the stream and all
+  its sink metadata and marks the stream destroyed. Concurrent sinks observe
+  the destruction and drop the stream instead of resurrecting its metadata;
+  only a subsequent `NewSink` or `AddStream` deliberately recreates it.
+- The stream TTL (see above) is restored whenever a sink attaches to the
+  stream, even when the consumer group already exists.
+
 ## Reading from multiple streams
 
 Readers and sinks can also read concurrently from multiple streams:

--- a/streaming/options/compat_test.go
+++ b/streaming/options/compat_test.go
@@ -1,0 +1,32 @@
+// Package options_test locks the v1 source compatibility of the exported
+// option structs: external code constructing them with unkeyed (positional)
+// literals must keep compiling. Adding, removing, reordering, or unexporting
+// a field breaks the literals below at compile time.
+package options_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"goa.design/pulse/pulse"
+	"goa.design/pulse/streaming/options"
+)
+
+// TestOptionStructsKeepV1PositionalShape compiles v1 unkeyed literals of
+// every exported option struct. The assertions only exist to consume the
+// literals; the test is about compilation.
+func TestOptionStructsKeepV1PositionalShape(t *testing.T) {
+	reader := options.ReaderOptions{time.Second, 100, "topic", "pattern", 10, "0"}
+	sink := options.SinkOptions{time.Second, 100, "topic", "pattern", 10, "0", true, time.Minute}
+	addStream := options.AddStreamOptions{"42-0"}
+	stream := options.StreamOptions{1000, pulse.NoopLogger(), time.Minute, true}
+	addEvent := options.AddEventOptions{"topic", true}
+
+	assert.Equal(t, time.Second, reader.BlockDuration)
+	assert.Equal(t, time.Minute, sink.AckGracePeriod)
+	assert.Equal(t, "42-0", addStream.LastEventID)
+	assert.Equal(t, 1000, stream.MaxLen)
+	assert.True(t, addEvent.OnlyIfStreamExists)
+}

--- a/streaming/reader.go
+++ b/streaming/reader.go
@@ -87,6 +87,20 @@ type (
 		// streamKey is the Redis key of the stream.
 		streamKey string
 	}
+
+	// readRetry computes jittered exponential backoff delays for reader and
+	// sink Redis failures. Jitter spans half to full of the current backoff
+	// so replicas that fail together do not retry in lockstep.
+	readRetry struct {
+		backoff time.Duration
+	}
+)
+
+const (
+	// minReadRetryBackoff is the first retry backoff after a Redis failure.
+	minReadRetryBackoff = 50 * time.Millisecond
+	// maxReadRetryBackoff caps the exponential retry backoff.
+	maxReadRetryBackoff = 5 * time.Second
 )
 
 // newReader creates a new reader.
@@ -230,16 +244,24 @@ func (r *Reader) start() {
 var xreadFn = (*Reader).xread
 
 // read reads events from the streams and sends them to the reader channel.
+// Transient Redis failures are retried with jittered exponential backoff so
+// reader replicas that fail together do not hammer Redis in lockstep.
 func (r *Reader) read() {
 	ctx := context.Background()
 	defer r.cleanup()
+	var retry readRetry
 	for {
 		streamsEvents, err := xreadFn(r, ctx)
 		if r.isClosing() {
 			return
 		}
 		if err != nil {
-			if err := handleReadError(err, r.logger); err != nil {
+			if err == redis.Nil {
+				// No event at this time, just loop.
+				retry.reset()
+				continue
+			}
+			if isFatalReaderError(err) {
 				r.logger.Error(fmt.Errorf("fatal error while reading events: %w, stopping", err))
 				// Close waits on this goroutine via wait.Wait, so calling it
 				// synchronously here would deadlock and leak the reader and its
@@ -248,13 +270,19 @@ func (r *Reader) read() {
 				pulse.Go(r.logger, r.Close)
 				return
 			}
+			if !retry.wait(r.donechan, err, r.logger) {
+				return
+			}
 			continue
 		}
+		retry.reset()
 
 		r.lock.Lock()
 		for _, events := range streamsEvents {
 			streamName := events.Stream[len(streamKeyPrefix):]
-			streamEvents(streamName, events.Stream, "", events.Messages, r.eventFilter, r.chans, r.donechan, r.rdb, r.logger)
+			if err := streamEvents(ctx, streamName, events.Stream, "", events.Messages, r.rdb, false, r.eventFilter, r.chans, r.donechan, r.logger); err != nil {
+				r.logger.Error(fmt.Errorf("failed to stream events: %w", err))
+			}
 			for i := range r.streamKeys {
 				if r.streamKeys[i] == events.Stream {
 					r.streamCursors[i] = events.Messages[len(events.Messages)-1].ID
@@ -319,21 +347,65 @@ func (e *Event) CreatedAt() time.Time {
 	return time.Unix(seconds, nanos).UTC()
 }
 
-// streamEvents filters and streams the Redis messages as events to c.
-// The caller is responsible for locking c.
+// reset clears the backoff so the next failure starts from the minimum delay.
+func (r *readRetry) reset() {
+	r.backoff = 0
+}
+
+// wait logs err and sleeps for the next jittered backoff delay. It returns
+// false when done closes during the wait, signaling the caller to stop.
+func (r *readRetry) wait(done <-chan struct{}, err error, logger pulse.Logger) bool {
+	d := r.next()
+	logger.Error(fmt.Errorf("failed to read events: %w, retrying in %v", err, d))
+	select {
+	case <-done:
+		return false
+	case <-time.After(d):
+		return true
+	}
+}
+
+// next returns a delay uniformly distributed in [backoff/2, backoff] and
+// doubles the backoff up to maxReadRetryBackoff.
+func (r *readRetry) next() time.Duration {
+	if r.backoff == 0 {
+		r.backoff = minReadRetryBackoff
+	}
+	d := r.backoff/2 + time.Duration(rand.Int63n(int64(r.backoff/2)+1))
+	r.backoff = min(2*r.backoff, maxReadRetryBackoff)
+	return d
+}
+
+// streamEvents filters and streams the Redis messages as events to the
+// subscriber channels. The caller is responsible for locking chans. For sinks
+// (sinkName non-empty) acker settles events that are never delivered to
+// subscribers so the recovery cursor keeps advancing: filtered events are
+// acknowledged individually, and when autoAck is set the whole batch is
+// settled upfront because delivery is already at-most-once.
 func streamEvents(
+	ctx context.Context,
 	streamName string,
 	streamKey string,
 	sinkName string,
 	msgs []redis.XMessage,
+	acker Acker,
+	autoAck bool,
 	eventFilter eventFilterFunc,
 	chans []chan *Event,
 	done <-chan struct{},
-	rdb *redis.Client,
 	logger pulse.Logger,
-) {
+) error {
 	if len(msgs) == 0 {
-		return
+		return nil
+	}
+	if autoAck && sinkName != "" {
+		ids := make([]string, len(msgs))
+		for i, msg := range msgs {
+			ids[i] = msg.ID
+		}
+		if err := acker.XAck(ctx, streamKey, sinkName, ids...).Err(); err != nil {
+			return fmt.Errorf("failed to advance recovery cursor for auto-acked events: %w", err)
+		}
 	}
 	for _, event := range msgs {
 		var topic string
@@ -348,9 +420,14 @@ func streamEvents(
 			Topic:      topic,
 			Payload:    []byte(event.Values[payloadKey].(string)),
 			streamKey:  streamKey,
-			Acker:      rdb,
+			Acker:      acker,
 		}
 		if eventFilter != nil && !eventFilter(ev) {
+			if sinkName != "" && !autoAck {
+				if err := acker.XAck(ctx, streamKey, sinkName, ev.ID).Err(); err != nil {
+					return fmt.Errorf("failed to acknowledge filtered event %s: %w", ev.ID, err)
+				}
+			}
 			logger.Debug("event filtered", "event", ev.EventName, "id", ev.ID, "stream", streamName)
 			continue
 		}
@@ -365,26 +442,15 @@ func streamEvents(
 				// remaining subscribers and messages in this batch are
 				// abandoned: delivery is at-most-once and the reader/sink
 				// is being torn down, so partial fan-out is acceptable.
-				return
+				return nil
 			}
 		}
 	}
+	return nil
 }
 
-// handleReadError retries retryable read errors and ignores non-retryable.
-func handleReadError(err error, logger pulse.Logger) error {
-	if strings.Contains(err.Error(), "stream key no longer exists") {
-		return err // Fatal error
-	}
-	if err == redis.Nil {
-		return nil // No event at this time, just loop
-	}
-	if strings.Contains(err.Error(), "NOGROUP") {
-		return nil // Consumer group was removed with RemoveStream, just loop (s.streamCursors will be updated)
-	}
-	// Retryable error, sleep and loop
-	d := time.Duration(rand.Intn(maxJitterMs)) * time.Millisecond
-	logger.Error(fmt.Errorf("failed to read events: %w, retrying in %v", err, d))
-	time.Sleep(d)
-	return nil
+// isFatalReaderError reports whether the read loop must stop instead of
+// retrying, which happens when the underlying stream key was destroyed.
+func isFatalReaderError(err error) bool {
+	return strings.Contains(err.Error(), "stream key no longer exists")
 }

--- a/streaming/sink.go
+++ b/streaming/sink.go
@@ -402,21 +402,17 @@ func (s *Sink) read() {
 
 // dispatch fans out one XREADGROUP reply to the subscribers, settling events
 // through the recovery acker. Batches for streams removed from the sink
-// concurrently with the read are acknowledged without delivery so the
-// recovery cursor keeps advancing for the remaining sink instances.
+// concurrently with the read are left pending, never acknowledged: if other
+// sink instances remain in the group, the fenced idle-claim redelivers the
+// entries to one of them (stale-consumer cleanup skips consumers with pending
+// events), and if this was the last member the group was already destroyed so
+// the pending entries are gone with it.
 func (s *Sink) dispatch(streams []redis.XStream) error {
 	for _, events := range streams {
 		s.lock.Lock()
 		state, owned := s.streams[events.Stream]
 		if !owned {
 			s.lock.Unlock()
-			ids := make([]string, len(events.Messages))
-			for i, msg := range events.Messages {
-				ids[i] = msg.ID
-			}
-			if err := s.acker.XAck(s.ctx, events.Stream, s.Name, ids...).Err(); err != nil {
-				s.logger.Error(fmt.Errorf("failed to settle events of removed stream %s: %w", events.Stream, err))
-			}
 			continue
 		}
 		err := streamEvents(s.ctx, state.stream.Name, state.stream.key, s.Name, events.Messages, s.acker, s.noAck, s.eventFilter, s.chans, s.donechan, s.logger)

--- a/streaming/sink.go
+++ b/streaming/sink.go
@@ -1,13 +1,21 @@
+// This file implements Sink, the consumer-group side of a stream. A sink read
+// loop XREADGROUPs events for every stream added to the sink, fans them out
+// to subscribers, and settles them through the recovery acker defined in
+// sink_recovery.go so the durable recovery cursor tracks exactly what was
+// acknowledged. Background goroutines refresh the sink keep-alive and, under
+// the fenced lease defined in sink_lease.go, claim idle messages and delete
+// stale consumers left behind by dead sink instances.
 package streaming
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"math/rand"
 	"regexp"
+	"sort"
 	"strconv"
-	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/oklog/ulid/v2"
@@ -19,27 +27,6 @@ import (
 	"goa.design/pulse/streaming/options"
 )
 
-var (
-	// maxJitterMs is the maximum retry backoff jitter in milliseconds.
-	maxJitterMs = 5000
-	// checkIdlePeriod is the period at which idle messages are checked.
-	checkIdlePeriod = 500 * time.Millisecond
-)
-
-// acquireLeaseScript is the script used to acquire the idle message check lease.
-var acquireLeaseScript = redis.NewScript(`
-    local key = KEYS[1]
-    local new_value = ARGV[1]
-    local current_time = ARGV[2]
-
-    local current_value = redis.call("GET", key)
-    if current_value == false or tonumber(current_value) < tonumber(current_time) then
-        redis.call("SET", key, new_value, "PX", ARGV[3])
-        return 1
-    end
-    return 0
-`)
-
 type (
 	// Sink represents a stream sink.
 	Sink struct {
@@ -49,19 +36,18 @@ type (
 		closed bool
 		// consumer is the sink consumer name.
 		consumer string
-		// leaseKeyName is the stale check lock key name.
-		leaseKeyName []string
+		// leaseOwner identifies this sink instance in the fenced lease used
+		// for idle message claiming and stale consumer cleanup.
+		leaseOwner string
 		// startID is the sink start event ID.
 		startID string
 		// noAck is true if there is no need to acknowledge events.
 		noAck bool
 		// lock is the sink mutex.
 		lock sync.Mutex
-		// streams are the streams the sink consumes events from.
-		streams []*Stream
-		// streamCursors is the stream cursors used to read events in
-		// the form [stream1, ">", stream2, ">", ...]
-		streamCursors []string
+		// streams are the streams the sink consumes events from, indexed by
+		// stream Redis key.
+		streams map[string]*sinkStream
 		// blockDuration is the XREADGROUP timeout.
 		blockDuration time.Duration
 		// maxPolled is the maximum number of events to read in one
@@ -77,34 +63,52 @@ type (
 		wait sync.WaitGroup
 		// closeOnce is used to ensure the sink is closed only once.
 		closeOnce sync.Once
-		// closing is true if Close was called.
-		closing bool
+		// closing is set when Close starts so loops stop scheduling work.
+		closing atomic.Bool
+		// ctx is canceled by Close to abort all sink-owned Redis I/O,
+		// including blocked XREADGROUP calls and recovery in progress.
+		ctx context.Context
+		// cancel cancels ctx.
+		cancel context.CancelFunc
 		// eventFilter is the event filter if any.
 		eventFilter eventFilterFunc
-		// consumersMap are the replicated maps used to track sink
-		// consumers.  Each map key is the sink name and the value is a list
-		// of consumer names.  consumersMap is indexed by stream name.
-		// consumer names are unique for each in-process sink instance.
-		consumersMap map[string]*rmap.Map
 		// consumersKeepAliveMap records consumer keep-alives for this
 		// sink (i.e. for all in-process instances of the sink).
 		consumersKeepAliveMap *rmap.Map
 		// ackGracePeriod is the grace period after which an event is
 		// considered unacknowledged.
 		ackGracePeriod time.Duration
-		// lastKeepAlive is the last keep-alive timestamp for this consumer.
+		// lastKeepAlive is the last keep-alive timestamp for this consumer
+		// in Redis-time nanoseconds.
 		lastKeepAlive int64
+		// acker settles events and advances the durable recovery cursor.
+		acker *recoveryAcker
 		// logger is the logger used by the sink.
 		logger pulse.Logger
-		// acquireLease is the acquire lease script.
-		acquireLease *redis.Script
 		// rdb is the redis connection.
 		rdb *redis.Client
+	}
+
+	// sinkStream is the sink-side state for one consumed stream: the stream
+	// handle, the start ID used when (re)creating the consumer group, and the
+	// replicated membership map listing the consumers of each sink.
+	sinkStream struct {
+		// stream is the consumed stream.
+		stream *Stream
+		// startID is the group start position for brand new groups.
+		startID string
+		// consumers is the stream membership map (sink name to consumer
+		// names), joined for reads and change notifications; all writes go
+		// through the fenced scripts in sink_recovery.go.
+		consumers *rmap.Map
 	}
 
 	// eventFilterFunc is the function used to filter events.
 	eventFilterFunc func(*Event) bool
 )
+
+// checkIdlePeriod is the period at which idle messages are checked.
+var checkIdlePeriod = 500 * time.Millisecond
 
 // newSink creates a new sink.
 // Sinks use one Redis consumer per stream they are consuming from.
@@ -124,65 +128,61 @@ func newSink(ctx context.Context, name string, stream *Stream, opts ...options.S
 		eventMatcher = func(e *Event) bool { return topicPatternRegexp.MatchString(e.Topic) }
 	}
 
-	if err := acquireLeaseScript.Load(ctx, stream.rdb).Err(); err != nil {
-		return nil, fmt.Errorf("failed to load stale check lease script: %w", err)
-	}
-
 	logger := stream.rootLogger.WithPrefix("sink", name)
-	cm, err := rmap.Join(ctx, consumersMapName(stream), stream.rdb, consumersMapOptions(stream, logger)...)
-	if err != nil {
-		return nil, fmt.Errorf("failed to join replicated map for sink %s: %w", name, err)
-	}
 	km, err := rmap.Join(ctx, sinkKeepAliveMapName(name), stream.rdb, rmap.WithLogger(logger))
 	if err != nil {
 		return nil, fmt.Errorf("failed to join replicated map for sink keep-alives %s: %w", name, err)
 	}
 
-	if err := stream.rdb.XGroupCreateMkStream(ctx, stream.key, name, o.LastEventID).Err(); err != nil && !isBusyGroupErr(err) {
-		return nil, fmt.Errorf("failed to create Redis consumer group %s for stream %s: %w", name, stream.Name, err)
-	}
-	if err := stream.applyTTL(ctx); err != nil {
-		return nil, fmt.Errorf("failed to apply stream TTL: %w", err)
-	}
+	// runCtx outlives the caller context and is canceled by Close so all
+	// sink-owned Redis I/O, including recovery in progress, stops promptly.
+	runCtx, cancel := context.WithCancel(log.WithContext(context.Background(), ctx))
 
 	sink := &Sink{
 		Name:                  name,
-		leaseKeyName:          []string{staleLockName(name)},
+		leaseOwner:            ulid.Make().String(),
 		startID:               o.LastEventID,
 		noAck:                 o.NoAck,
-		streams:               []*Stream{stream},
-		streamCursors:         []string{stream.key, ">"},
+		streams:               make(map[string]*sinkStream, 1),
 		blockDuration:         o.BlockDuration,
 		maxPolled:             o.MaxPolled,
 		bufferSize:            o.BufferSize,
 		donechan:              make(chan struct{}),
+		ctx:                   runCtx,
+		cancel:                cancel,
 		eventFilter:           eventMatcher,
-		consumersMap:          map[string]*rmap.Map{stream.Name: cm},
 		consumersKeepAliveMap: km,
 		ackGracePeriod:        o.AckGracePeriod,
-		acquireLease:          acquireLeaseScript,
+		acker:                 &recoveryAcker{rdb: stream.rdb},
 		logger:                logger,
 		rdb:                   stream.rdb,
 	}
 
-	// Clean up any existing stale consumers before creating our own
-	if err := sink.deleteStreamStaleConsumers(ctx, stream); err != nil {
-		sink.logger.Error(fmt.Errorf("failed to cleanup stale consumers: %w", err))
-	}
-
-	consumer, err := sink.newConsumer(ctx, stream)
+	state, err := sink.attachStream(ctx, stream, o.LastEventID)
 	if err != nil {
+		cancel()
+		km.Close()
+		return nil, err
+	}
+	sink.streams[stream.key] = state
+
+	consumer, err := sink.newConsumer(ctx)
+	if err != nil {
+		// Compensate the group and cursor created by attachStream (the group
+		// survives only when other sink instances are members).
+		if cerr := removeSinkStream(ctx, stream, name, ""); cerr != nil {
+			err = errors.Join(err, cerr)
+		}
+		cancel()
+		state.consumers.Close()
+		km.Close()
 		return nil, fmt.Errorf("failed to create consumer: %w", err)
 	}
 	sink.consumer = consumer
 	sink.logger = sink.logger.WithPrefix("consumer", consumer)
 
-	// create new logger context for goroutines.
-	logCtx := context.Background()
-	logCtx = log.WithContext(logCtx, ctx)
-
 	sink.wait.Add(3)
-	pulse.Go(logger, func() { sink.read(logCtx) })
+	pulse.Go(logger, sink.read)
 	pulse.Go(logger, sink.periodicKeepAlive)
 	pulse.Go(logger, sink.periodicIdleMessageCheck)
 
@@ -213,7 +213,7 @@ func (s *Sink) Unsubscribe(c <-chan *Event) {
 	}
 }
 
-// Ack acknowledges the event.
+// Ack acknowledges the event and advances the sink recovery cursor.
 func (s *Sink) Ack(ctx context.Context, e *Event) error {
 	err := e.Acker.XAck(ctx, e.streamKey, e.SinkName, e.ID).Err()
 	if err != nil {
@@ -227,84 +227,76 @@ func (s *Sink) Ack(ctx context.Context, e *Event) error {
 // AddStream adds the stream to the sink. By default the stream cursor starts at
 // the same timestamp as the sink main stream cursor.  This can be overridden
 // with opts. AddStream does nothing if the stream is already part of the sink.
+// It returns ErrSinkClosed after Close.
 func (s *Sink) AddStream(ctx context.Context, stream *Stream, opts ...options.AddStream) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	for _, s := range s.streams {
-		if s.Name == stream.Name {
-			return nil
-		}
+	if s.closing.Load() {
+		return ErrSinkClosed
+	}
+	if _, ok := s.streams[stream.key]; ok {
+		return nil
 	}
 	startID := s.startID
-	options := options.ParseAddStreamOptions(opts...)
-	for _, option := range opts {
-		option(&options)
+	o := options.ParseAddStreamOptions(opts...)
+	if o.LastEventID != "" {
+		startID = o.LastEventID
 	}
-	if options.LastEventID != "" {
-		startID = options.LastEventID
-	}
-
-	cm, err := rmap.Join(ctx, consumersMapName(stream), stream.rdb, consumersMapOptions(stream, stream.logger)...)
+	state, err := s.attachStream(ctx, stream, startID)
 	if err != nil {
-		return fmt.Errorf("failed to join consumer replicated map for stream %s: %w", stream.Name, err)
+		return err
 	}
-	if _, err := cm.AppendValues(ctx, s.Name, s.consumer); err != nil {
-		return fmt.Errorf("failed to append consumer %s to replicated map for stream %s: %w", s.consumer, stream.Name, err)
+	if err := registerSinkConsumer(ctx, stream, s.Name, s.consumer); err != nil {
+		// Compensate the group and cursor created by attachStream so a failed
+		// AddStream leaves no dangling ownership state (the group survives
+		// only when other sink instances are members).
+		if cerr := removeSinkStream(ctx, stream, s.Name, s.consumer); cerr != nil {
+			err = errors.Join(err, cerr)
+		}
+		state.consumers.Close()
+		return err
 	}
-	if err := stream.rdb.XGroupCreateMkStream(ctx, stream.key, s.Name, startID).Err(); err != nil && !isBusyGroupErr(err) {
-		return fmt.Errorf("failed to create Redis consumer group %s for stream %s: %w", s.Name, stream.Name, err)
-	}
-	s.streams = append(s.streams, stream)
-	s.streamCursors = make([]string, len(s.streams)*2)
-	for i, stream := range s.streams {
-		s.streamCursors[i] = stream.key
-		s.streamCursors[len(s.streams)+i] = ">"
-	}
-	s.consumersMap[stream.Name] = cm
+	s.streams[stream.key] = state
 	s.logger.Info("added", "stream", stream.Name)
 	return nil
 }
 
-// RemoveStream removes the stream from the sink, it is idempotent.
+// RemoveStream removes the stream from the sink, it is idempotent. The
+// distributed effects (membership removal and, for the last member, consumer
+// group, recovery cursor, and lease deletion) execute in one atomic script so
+// there is no partial state to compensate. It returns ErrSinkClosed after
+// Close.
 func (s *Sink) RemoveStream(ctx context.Context, stream *Stream) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
-	found := false
-	for i, st := range s.streams {
-		if st == stream {
-			s.streams = append(s.streams[:i], s.streams[i+1:]...)
-			found = true
-			break
-		}
+	if s.closing.Load() {
+		return ErrSinkClosed
 	}
-	if !found {
+	state, ok := s.streams[stream.key]
+	if !ok {
 		return nil
 	}
-	s.streamCursors = make([]string, len(s.streams)*2)
-	for i, stream := range s.streams {
-		s.streamCursors[i] = stream.key
-		s.streamCursors[len(s.streams)+i] = ">"
-	}
-	if err := s.removeStreamConsumer(ctx, stream); err != nil {
+	if err := removeSinkStream(ctx, state.stream, s.Name, s.consumer); err != nil {
 		return err
 	}
+	delete(s.streams, stream.key)
+	state.consumers.Close()
 	s.logger.Info("removed", "stream", stream.Name)
 	return nil
 }
 
-// Close stops event polling, waits for all events to be processed, and closes the sink channel.
-// It is safe to call Close multiple times; concurrent callers block until the
-// first Close completes.
+// Close stops event polling, cancels all sink-owned Redis I/O (including any
+// recovery in progress), waits for the sink goroutines to stop, and closes
+// the sink channels. It is safe to call Close multiple times; concurrent
+// callers block until the first Close completes.
 func (s *Sink) Close(ctx context.Context) {
 	s.closeOnce.Do(func() {
-		// Close donechan first, without holding the lock, so the signal
-		// reaches the read loop even when it is parked on a fan-out send
-		// to a stalled subscriber (which holds the lock). Otherwise Close
-		// would deadlock acquiring the lock the read loop never releases.
+		// Signal shutdown without holding the lock so the read loop stops
+		// even when it is parked on a fan-out send to a stalled subscriber
+		// (which holds the lock) or blocked in a Redis call.
+		s.closing.Store(true)
+		s.cancel()
 		close(s.donechan)
-		s.lock.Lock()
-		s.closing = true
-		s.lock.Unlock()
 		s.wait.Wait()
 		s.lock.Lock()
 		defer s.lock.Unlock()
@@ -314,8 +306,8 @@ func (s *Sink) Close(ctx context.Context) {
 		// Note: we do not delete the consumer from the keep-alive and consumer maps
 		// so that another instance may claim any pending messages.
 		s.consumersKeepAliveMap.Close()
-		for _, cm := range s.consumersMap {
-			cm.Close()
+		for _, state := range s.streams {
+			state.consumers.Close()
 		}
 		s.closed = true
 		s.logger.Info("closed")
@@ -329,180 +321,238 @@ func (s *Sink) IsClosed() bool {
 	return s.closed
 }
 
-// deleteStreamStaleConsumers deletes stale consumers for a specific stream.
-// s.lock must be held.
-func (s *Sink) deleteStreamStaleConsumers(ctx context.Context, stream *Stream) error {
-	// Get all consumers for this group
-	consumers, err := s.rdb.XInfoConsumers(ctx, stream.key, s.Name).Result()
+// attachStream ensures the consumer group and recovery cursor exist for the
+// stream (restoring the stream TTL even on BUSYGROUP) and joins the stream
+// membership map. Callers own registering the sink consumer.
+func (s *Sink) attachStream(ctx context.Context, stream *Stream, startID string) (*sinkStream, error) {
+	if _, _, err := ensureConsumerGroup(ctx, stream, s.Name, startID, true); err != nil {
+		return nil, err
+	}
+	cm, err := rmap.Join(ctx, consumersMapName(stream), stream.rdb, consumersMapOptions(stream, s.logger)...)
 	if err != nil {
-		return fmt.Errorf("failed to get consumers info: %w", err)
+		return nil, fmt.Errorf("failed to join replicated map for stream %s: %w", stream.Name, err)
 	}
-
-	// Check keep-alive map
-	keepAlives := s.consumersKeepAliveMap.Map()
-	for _, consumer := range consumers {
-		ts, hasKeepAlive := keepAlives[consumer.Name]
-		if !hasKeepAlive {
-			s.logger.Info("cleaning up consumer with no keep-alive", "consumer", consumer.Name)
-			if err := s.rdb.XGroupDelConsumer(ctx, stream.key, s.Name, consumer.Name).Err(); err != nil {
-				s.logger.Error(fmt.Errorf("failed to delete consumer with no keep-alive: %w", err), "consumer", consumer.Name)
-			}
-			continue
-		}
-
-		// Check if consumer is stale based on keep-alive timestamp
-		keepAliveTs, err := strconv.ParseInt(ts, 10, 64)
-		if err != nil {
-			s.logger.Error(fmt.Errorf("failed to parse keep-alive timestamp: %w", err), "consumer", consumer.Name, "timestamp", ts)
-			continue
-		}
-
-		if time.Since(time.Unix(0, keepAliveTs)) > 2*s.ackGracePeriod {
-			s.logger.Info("cleaning up stale consumer", "consumer", consumer.Name)
-			if err := s.rdb.XGroupDelConsumer(ctx, stream.key, s.Name, consumer.Name).Err(); err != nil {
-				s.logger.Error(fmt.Errorf("failed to delete stale consumer: %w", err), "consumer", consumer.Name)
-			}
-			if _, err := s.consumersKeepAliveMap.Delete(ctx, consumer.Name); err != nil {
-				s.logger.Error(fmt.Errorf("failed to delete keep-alive for stale consumer: %w", err), "consumer", consumer.Name)
-			}
-			if sinks := s.consumersMap[stream.Name]; sinks != nil {
-				if _, _, err := sinks.RemoveValues(ctx, s.Name, consumer.Name); err != nil {
-					s.logger.Error(fmt.Errorf("failed to remove consumer from map: %w", err), "stream", stream.Name, "consumer", consumer.Name)
-				}
-			}
-		}
-	}
-	return nil
+	return &sinkStream{stream: stream, startID: startID, consumers: cm}, nil
 }
 
-// deleteStaleConsumers deletes stale consumers.
-// s.lock must be held.
-func (s *Sink) deleteStaleConsumers(ctx context.Context) {
-	for _, stream := range s.streams {
-		if err := s.deleteStreamStaleConsumers(ctx, stream); err != nil {
-			s.logger.Error(fmt.Errorf("failed to delete stale consumers for stream %s: %w", stream.Name, err))
-		}
-	}
-}
-
-// removeStreamConsumer removes the stream consumer from the sink.
-func (s *Sink) removeStreamConsumer(ctx context.Context, stream *Stream) error {
-	remains, _, err := s.consumersMap[stream.Name].RemoveValues(ctx, s.Name, s.consumer)
-	if err != nil {
-		return fmt.Errorf("failed to remove consumer %s from replicated map for stream %s: %w", s.consumer, stream.Name, err)
-	}
-	if len(remains) == 0 {
-		if err := s.deleteConsumerGroup(ctx, stream); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// newConsumer creates a new consumer and registers it in the consumers and
-// keep-alive maps.
-func (s *Sink) newConsumer(ctx context.Context, stream *Stream) (string, error) {
-	consumer := ulid.Make().String()
-	if err := stream.rdb.XGroupCreateConsumer(ctx, stream.key, s.Name, consumer).Err(); err != nil {
-		return "", fmt.Errorf("failed to create Redis consumer %s for consumer group %s: %w", consumer, s.Name, err)
-	}
-	if _, err := s.consumersMap[stream.Name].AppendValues(ctx, s.Name, consumer); err != nil {
-		if err := stream.rdb.XGroupDelConsumer(ctx, stream.key, s.Name, consumer).Err(); err != nil {
-			s.logger.Error(fmt.Errorf("failed to delete consumer %s after failed append: %w", consumer, err))
-		}
-		return "", fmt.Errorf("failed to append store consumer %s for sink %s: %w", consumer, s.Name, err)
-	}
-	s.lastKeepAlive = time.Now().UnixNano()
-	if _, err := s.consumersKeepAliveMap.Set(ctx, consumer, strconv.FormatInt(s.lastKeepAlive, 10)); err != nil {
-		if err := stream.rdb.XGroupDelConsumer(ctx, stream.key, s.Name, consumer).Err(); err != nil {
-			s.logger.Error(fmt.Errorf("failed to delete consumer %s after failed keep-alive set: %w", consumer, err))
-		}
-		return "", fmt.Errorf("failed to set sink keep-alive for new consumer %s: %w", consumer, err)
-	}
-	return consumer, nil
-}
-
-// read reads events from the streams and sends them to the sink channel.
-func (s *Sink) read(ctx context.Context) {
+// read reads events from the streams and sends them to the sink channels.
+// NOGROUP errors trigger lossless consumer group recovery; transient Redis
+// failures are retried with jittered exponential backoff.
+func (s *Sink) read() {
 	defer s.logger.Debug("read: exiting")
 	defer s.wait.Done()
+	var retry readRetry
 	for {
-		if err := s.ensureConsumer(ctx); err != nil {
-			time.Sleep(time.Duration(rand.Int63n(int64(s.blockDuration))))
+		if err := s.ensureConsumer(s.ctx); err != nil {
+			if s.closing.Load() {
+				return
+			}
+			if !retry.wait(s.donechan, err, s.logger) {
+				return
+			}
 			continue
 		}
-		s.lock.Lock()
-		readStreams := make([]string, len(s.streamCursors))
-		copy(readStreams, s.streamCursors)
-		s.lock.Unlock()
-
-		s.logger.Debug("reading", "streams", readStreams, "max", s.maxPolled, "block", s.blockDuration)
-		streams, err := s.rdb.XReadGroup(ctx, &redis.XReadGroupArgs{
+		args, consumer := s.readArgs()
+		if len(args) == 0 {
+			// No streams to read from; wait for AddStream or Close.
+			select {
+			case <-s.donechan:
+				return
+			case <-time.After(s.blockDuration):
+				continue
+			}
+		}
+		s.logger.Debug("reading", "streams", args, "max", s.maxPolled, "block", s.blockDuration)
+		streams, err := s.rdb.XReadGroup(s.ctx, &redis.XReadGroupArgs{
 			Group:    s.Name,
-			Consumer: s.consumer,
-			Streams:  readStreams,
+			Consumer: consumer,
+			Streams:  args,
 			Count:    s.maxPolled,
 			Block:    s.blockDuration,
 			NoAck:    s.noAck,
 		}).Result()
-
-		s.lock.Lock()
-		if s.closing {
-			s.lock.Unlock()
+		if s.closing.Load() {
 			// Honor the Close contract and do not forward any more events.
 			// Any events in the PEL will be claimed by another consumer.
 			return
 		}
-		if err != nil {
-			if err := handleReadError(err, s.logger); err != nil {
-				s.logger.Error(fmt.Errorf("error reading events: %w", err))
-			}
-			s.lock.Unlock()
+		if err == nil {
+			err = s.dispatch(streams)
+		}
+		if err == nil || err == redis.Nil {
+			retry.reset()
 			continue
 		}
-		for _, events := range streams {
-			streamName := events.Stream[len(streamKeyPrefix):]
-			streamEvents(streamName, events.Stream, s.Name, events.Messages, s.eventFilter, s.chans, s.donechan, s.rdb, s.logger)
+		if redis.HasErrorPrefix(err, "NOGROUP") {
+			if err := s.recoverConsumerGroups(s.ctx); err == nil {
+				retry.reset()
+				continue
+			} else if s.closing.Load() {
+				return
+			} else if !retry.wait(s.donechan, err, s.logger) {
+				return
+			}
+			continue
 		}
-		s.lock.Unlock()
+		if !retry.wait(s.donechan, err, s.logger) {
+			return
+		}
 	}
 }
 
-// ensureConsumer ensures that the consumer is still alive.
-func (s *Sink) ensureConsumer(ctx context.Context) error {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-	if time.Since(time.Unix(0, s.lastKeepAlive)) > 2*s.ackGracePeriod {
-		s.logger.Debug("consumer stale, creating new one")
-		var err error
-		s.consumer, err = s.newConsumer(ctx, s.streams[0])
+// dispatch fans out one XREADGROUP reply to the subscribers, settling events
+// through the recovery acker. Batches for streams removed from the sink
+// concurrently with the read are acknowledged without delivery so the
+// recovery cursor keeps advancing for the remaining sink instances.
+func (s *Sink) dispatch(streams []redis.XStream) error {
+	for _, events := range streams {
+		s.lock.Lock()
+		state, owned := s.streams[events.Stream]
+		if !owned {
+			s.lock.Unlock()
+			ids := make([]string, len(events.Messages))
+			for i, msg := range events.Messages {
+				ids[i] = msg.ID
+			}
+			if err := s.acker.XAck(s.ctx, events.Stream, s.Name, ids...).Err(); err != nil {
+				s.logger.Error(fmt.Errorf("failed to settle events of removed stream %s: %w", events.Stream, err))
+			}
+			continue
+		}
+		err := streamEvents(s.ctx, state.stream.Name, state.stream.key, s.Name, events.Messages, s.acker, s.noAck, s.eventFilter, s.chans, s.donechan, s.logger)
+		s.lock.Unlock()
 		if err != nil {
-			s.logger.Error(fmt.Errorf("failed to create new consumer: %w", err))
 			return err
 		}
 	}
 	return nil
 }
 
-// periodicKeepAlive updates this consumer keep-alive every half ack grace period.
+// recoverConsumerGroups recreates missing consumer groups at the durable
+// recovery cursor after Redis loses group state (e.g. XGROUP DESTROY). A
+// stream that was destroyed with Stream.Destroy is dropped from the sink
+// instead of being resurrected.
+func (s *Sink) recoverConsumerGroups(ctx context.Context) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	for key, state := range s.streams {
+		created, cursor, err := ensureConsumerGroup(ctx, state.stream, s.Name, state.startID, false)
+		if err != nil {
+			if errors.Is(err, ErrStreamDestroyed) {
+				s.logger.Info("stream destroyed, dropping from sink", "stream", state.stream.Name)
+				delete(s.streams, key)
+				state.consumers.Close()
+				continue
+			}
+			return err
+		}
+		if created {
+			s.logger.Info("recovered consumer group", "stream", state.stream.Name, "cursor", cursor)
+		}
+	}
+	return nil
+}
+
+// readArgs snapshots the XREADGROUP stream arguments and the current consumer
+// under the sink lock.
+func (s *Sink) readArgs() ([]string, string) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	keys := make([]string, 0, len(s.streams))
+	for key := range s.streams {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	args := make([]string, 2*len(keys))
+	for i, key := range keys {
+		args[i] = key
+		args[len(keys)+i] = ">"
+	}
+	return args, s.consumer
+}
+
+// ensureConsumer rotates the sink consumer when its keep-alive went stale,
+// e.g. after this instance was partitioned long enough for its consumer to be
+// cleaned up by a replica. Staleness is evaluated against Redis time so
+// client clocks do not skew the decision.
+func (s *Sink) ensureConsumer(ctx context.Context) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	now, err := s.rdb.Time(ctx).Result()
+	if err != nil {
+		return fmt.Errorf("failed to read Redis time: %w", err)
+	}
+	if now.Sub(time.Unix(0, s.lastKeepAlive)) <= 2*s.ackGracePeriod {
+		return nil
+	}
+	s.logger.Debug("consumer stale, creating new one")
+	consumer, err := s.newConsumer(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create new consumer: %w", err)
+	}
+	s.consumer = consumer
+	return nil
+}
+
+// newConsumer creates a new consumer, registers it with every sink stream,
+// and records its keep-alive. Registration is failure-atomic: when any
+// registration fails the consumer is detached from the streams registered so
+// far so ownership state never diverges across streams. s.lock must be held.
+func (s *Sink) newConsumer(ctx context.Context) (string, error) {
+	consumer := ulid.Make().String()
+	registered := make([]*sinkStream, 0, len(s.streams))
+	rollback := func(cause error) error {
+		var errs []error
+		for _, state := range registered {
+			if err := detachSinkConsumer(ctx, state.stream, s.Name, consumer); err != nil {
+				errs = append(errs, err)
+			}
+		}
+		return errors.Join(append([]error{cause}, errs...)...)
+	}
+	for _, state := range s.streams {
+		if err := registerSinkConsumer(ctx, state.stream, s.Name, consumer); err != nil {
+			return "", rollback(err)
+		}
+		registered = append(registered, state)
+	}
+	now, err := s.rdb.Time(ctx).Result()
+	if err != nil {
+		return "", rollback(fmt.Errorf("failed to read Redis time for new consumer %s: %w", consumer, err))
+	}
+	keepAlive := now.UnixNano()
+	if _, err := s.consumersKeepAliveMap.Set(ctx, consumer, strconv.FormatInt(keepAlive, 10)); err != nil {
+		return "", rollback(fmt.Errorf("failed to set sink keep-alive for new consumer %s: %w", consumer, err))
+	}
+	s.lastKeepAlive = keepAlive
+	return consumer, nil
+}
+
+// periodicKeepAlive updates this consumer keep-alive every ack grace period
+// using Redis time so replicas evaluating staleness agree on the clock.
 func (s *Sink) periodicKeepAlive() {
 	defer s.wait.Done()
 	defer s.logger.Debug("periodicKeepAlive: exiting")
 	ticker := time.NewTicker(s.ackGracePeriod)
 	defer ticker.Stop()
 
-	ctx := context.Background()
 	for {
 		select {
 		case <-ticker.C:
 			s.lock.Lock()
-			now := time.Now().UnixNano()
-			if _, err := s.consumersKeepAliveMap.Set(ctx, s.consumer, strconv.FormatInt(now, 10)); err != nil {
-				s.logger.Error(fmt.Errorf("failed to update sink keep-alive: %v", err))
+			now, err := s.rdb.Time(s.ctx).Result()
+			if err != nil {
+				s.logger.Error(fmt.Errorf("failed to read Redis time for keep-alive: %w", err))
 				s.lock.Unlock()
 				continue
 			}
-			s.lastKeepAlive = now
+			keepAlive := now.UnixNano()
+			if _, err := s.consumersKeepAliveMap.Set(s.ctx, s.consumer, strconv.FormatInt(keepAlive, 10)); err != nil {
+				s.logger.Error(fmt.Errorf("failed to update sink keep-alive: %w", err))
+				s.lock.Unlock()
+				continue
+			}
+			s.lastKeepAlive = keepAlive
 			s.lock.Unlock()
 
 		case <-s.donechan:
@@ -511,34 +561,24 @@ func (s *Sink) periodicKeepAlive() {
 	}
 }
 
-// periodicIdleMessageCheck claims any idle message every check stale period.
-// An idle message is one that has not been acked for more than the ack grace period.
-// Once all idle messages are claimed, any stale consumer is deleted.
+// periodicIdleMessageCheck claims idle messages and deletes stale consumers
+// under the per-stream fenced lease. An idle message is one that has not been
+// acked for more than the ack grace period. Lease renewal and each guarded
+// mutation execute in one atomic script so a stale owner cannot mutate the
+// PEL after another instance takes over.
 func (s *Sink) periodicIdleMessageCheck() {
 	defer s.wait.Done()
 	defer s.logger.Debug("periodicIdleMessageCheck: exiting")
 	ticker := time.NewTicker(checkIdlePeriod)
 	defer ticker.Stop()
 
-	leaseDuration := checkIdlePeriod.Milliseconds() - 5
-	ctx := context.Background()
 	for {
 		select {
 		case <-ticker.C:
-			now := time.Now().UnixNano() / int64(time.Millisecond)
-			newExpiration := now + leaseDuration
-			result, err := s.acquireLease.EvalSha(ctx, s.rdb, s.leaseKeyName, newExpiration, now, leaseDuration).Result()
-			if err != nil {
-				s.logger.Error(fmt.Errorf("failed to acquire idle message check lease: %v", err))
-				continue
-			}
-			if result != int64(1) {
-				// Another sink instance claimed the lease.
-				continue
-			}
 			s.lock.Lock()
-			s.claimIdleMessages(ctx)
-			s.deleteStaleConsumers(ctx)
+			for _, state := range s.streams {
+				s.checkIdleMessages(s.ctx, state)
+			}
 			s.lock.Unlock()
 
 		case <-s.donechan:
@@ -547,55 +587,60 @@ func (s *Sink) periodicIdleMessageCheck() {
 	}
 }
 
-// claimIdleMessages claims idle messages from the streams.
-// s.lock must be held.
-func (s *Sink) claimIdleMessages(ctx context.Context) {
-	for _, stream := range s.streams {
-		args := redis.XAutoClaimArgs{
-			Stream:   stream.key,
-			Group:    s.Name,
-			MinIdle:  s.ackGracePeriod,
-			Start:    "0-0",
-			Consumer: s.consumer,
+// checkIdleMessages acquires the stream lease and, when held, claims idle
+// messages for this consumer and deletes stale consumers. Lease loss and
+// stream destruction abort silently: another instance owns the work or the
+// stream is gone. s.lock must be held.
+func (s *Sink) checkIdleMessages(ctx context.Context, state *sinkStream) {
+	// Note: the builtin max is shadowed by the package-level test helper
+	// variable of the same name, hence the explicit floor.
+	leaseMs := 2 * checkIdlePeriod.Milliseconds()
+	if leaseMs < 20 {
+		leaseMs = 20
+	}
+	acquired, fence, err := acquireSinkLease(ctx, state.stream, s.Name, s.leaseOwner, leaseMs)
+	if err != nil {
+		if !errors.Is(err, ErrStreamDestroyed) && ctx.Err() == nil {
+			s.logger.Error(fmt.Errorf("failed to acquire idle message check lease: %w", err))
 		}
-		start, err := s.claim(ctx, stream.Name, args)
+		return
+	}
+	if !acquired {
+		// Another sink instance owns the lease.
+		return
+	}
+	start := "0-0"
+	for {
+		msgs, next, err := fencedAutoClaim(ctx, state.stream, s.Name, s.leaseOwner, fence, leaseMs, s.consumer, s.ackGracePeriod.Milliseconds(), start, s.maxPolled)
 		if err != nil {
-			s.logger.Error(fmt.Errorf("failed to claim idle messages for stream %s: %w", stream.Name, err))
-			continue
+			if !isLeaseLostErr(err) && !isStreamDestroyedErr(err) && ctx.Err() == nil {
+				s.logger.Error(fmt.Errorf("failed to claim idle messages for stream %s: %w", state.stream.Name, err))
+			}
+			return
 		}
-		for start != "0-0" {
-			args.Start = start
-			start, err = s.claim(ctx, stream.Name, args)
-			if err != nil {
-				s.logger.Error(fmt.Errorf("failed to claim idle messages for stream %s: %w", stream.Name, err))
-				break
+		if len(msgs) > 0 {
+			s.logger.Info("claimed", "stream", state.stream.Name, "messages", len(msgs))
+			if err := streamEvents(ctx, state.stream.Name, state.stream.key, s.Name, msgs, s.acker, s.noAck, s.eventFilter, s.chans, s.donechan, s.logger); err != nil {
+				s.logger.Error(fmt.Errorf("failed to stream claimed events: %w", err))
+				return
 			}
 		}
+		if next == "0-0" {
+			break
+		}
+		start = next
 	}
-}
-
-// Helper function to claim messages from a stream used by claimIdleMessages.
-func (s *Sink) claim(ctx context.Context, streamName string, args redis.XAutoClaimArgs) (string, error) {
-	messages, start, err := s.rdb.XAutoClaim(ctx, &args).Result()
-	if len(messages) > 0 {
-		s.logger.Info("claimed", "stream", streamName, "messages", len(messages))
-		streamEvents(streamName, args.Stream, s.Name, messages, s.eventFilter, s.chans, s.donechan, s.rdb, s.logger)
+	staleNs := (2 * s.ackGracePeriod).Nanoseconds()
+	removed, err := fencedCleanupStaleConsumers(ctx, state.stream, s.Name, s.leaseOwner, fence, leaseMs, staleNs, s.consumer)
+	if err != nil {
+		if !isLeaseLostErr(err) && !isStreamDestroyedErr(err) && ctx.Err() == nil {
+			s.logger.Error(fmt.Errorf("failed to delete stale consumers for stream %s: %w", state.stream.Name, err))
+		}
+		return
 	}
-	return start, err
-}
-
-// deleteConsumerGroup deletes the consumer group.
-func (s *Sink) deleteConsumerGroup(ctx context.Context, stream *Stream) error {
-	if err := s.rdb.XGroupDestroy(ctx, stream.key, s.Name).Err(); err != nil {
-		return fmt.Errorf("failed to destroy Redis consumer group %q for stream %q: %w", s.Name, stream.Name, err)
+	if len(removed) > 0 {
+		s.logger.Info("deleted stale consumers", "stream", state.stream.Name, "consumers", removed)
 	}
-	delete(s.consumersMap, stream.Name)
-	return nil
-}
-
-// isBusyGroupErr returns true if the error is a busy group error.
-func isBusyGroupErr(err error) bool {
-	return strings.Contains(err.Error(), "BUSYGROUP")
 }
 
 // consumersMapName is the name of the replicated map that backs a sink.
@@ -620,9 +665,4 @@ func consumersMapOptions(stream *Stream, logger pulse.Logger) []rmap.MapOption {
 // sinkKeepAliveMapName is the name of the replicated map that backs a sink keep-alives.
 func sinkKeepAliveMapName(sink string) string {
 	return fmt.Sprintf("sink:%s:keepalive", sink)
-}
-
-// staleLockName is the name of the lock used to check for stale messages.
-func staleLockName(sink string) string {
-	return fmt.Sprintf("sink:%s:stalelease", sink)
 }

--- a/streaming/sink_lease.go
+++ b/streaming/sink_lease.go
@@ -1,0 +1,263 @@
+// This file implements the fenced sink lease used for idle-message claiming
+// and stale-consumer cleanup.
+//
+// Each sink (consumer group) holds at most one lease per stream, stored in a
+// hash at "pulse:streammeta:<stream>:sink:<sink>:lease" with fields:
+//
+//   - owner:  the sink instance currently allowed to claim and clean up.
+//   - fence:  a counter incremented on every ownership change.
+//   - expiry: Redis-time (milliseconds) after which the lease is up for grabs.
+//
+// All timing uses the Redis TIME command evaluated inside the scripts so
+// client clock skew cannot grant two instances the lease at once. Lease
+// verification, renewal, and the guarded mutation (XAUTOCLAIM or consumer
+// deletion) execute in a single script: once another instance takes over the
+// lease the fence counter changes and every in-flight script from the stale
+// owner fails before touching the PEL.
+package streaming
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	redis "github.com/redis/go-redis/v9"
+)
+
+// leaseLostErrorPrefix is the Redis error prefix returned by fenced scripts
+// when the caller no longer holds the lease.
+const leaseLostErrorPrefix = "LEASELOST"
+
+// leaseCheckLua verifies and renews the caller's lease. Scripts using it must
+// bind KEYS[2] to the lease key, ARGV[1] to the owner, ARGV[2] to the fence
+// value returned by acquisition, and ARGV[3] to the lease duration in
+// milliseconds. It defines now_ms for subsequent statements.
+const leaseCheckLua = `
+local t = redis.call("TIME")
+local now_ms = t[1] * 1000 + math.floor(t[2] / 1000)
+local owner = redis.call("HGET", KEYS[2], "owner")
+local fence = redis.call("HGET", KEYS[2], "fence")
+local expiry = tonumber(redis.call("HGET", KEYS[2], "expiry") or "0")
+if owner ~= ARGV[1] or fence ~= ARGV[2] or expiry < now_ms then
+   return redis.error_reply("LEASELOST sink lease lost")
+end
+redis.call("HSET", KEYS[2], "expiry", now_ms + tonumber(ARGV[3]))
+redis.call("PEXPIRE", KEYS[2], tonumber(ARGV[3]) * 2)
+`
+
+// acquireLeaseScript acquires or renews the sink lease using Redis time. A
+// new owner (or a takeover of an expired lease) increments the fence counter
+// so scripts still carrying the previous fence value can no longer mutate
+// anything. Acquisition is fenced by the stream lifecycle: destroyed streams
+// never get a new lease key.
+//
+// KEYS: [1]=lifecycle [2]=lease
+// ARGV: [1]=owner [2]=leaseMs
+// Returns {acquired(0|1), fence}.
+var acquireLeaseScript = redis.NewScript(`
+local state = redis.call("HGET", KEYS[1], "state")
+if state ~= "active" then
+   return redis.error_reply("STREAMDESTROYED stream was destroyed")
+end
+local t = redis.call("TIME")
+local now_ms = t[1] * 1000 + math.floor(t[2] / 1000)
+local owner = redis.call("HGET", KEYS[2], "owner")
+local expiry = tonumber(redis.call("HGET", KEYS[2], "expiry") or "0")
+if owner and owner ~= ARGV[1] and expiry >= now_ms then
+   return {0, 0}
+end
+local bump = 1
+if owner == ARGV[1] and expiry >= now_ms then
+   bump = 0
+end
+local fence = redis.call("HINCRBY", KEYS[2], "fence", bump)
+redis.call("HSET", KEYS[2], "owner", ARGV[1], "expiry", now_ms + tonumber(ARGV[2]))
+redis.call("PEXPIRE", KEYS[2], tonumber(ARGV[2]) * 2)
+return {1, fence}
+`)
+
+// fencedAutoClaimScript renews the lease and claims idle messages in one
+// atomic operation so a stale owner cannot move PEL entries after takeover.
+//
+// KEYS: [1]=lifecycle [2]=lease [3]=stream
+// ARGV: [1]=owner [2]=fence [3]=leaseMs [4]=group [5]=consumer [6]=minIdleMs
+// [7]=start [8]=count
+// Returns the XAUTOCLAIM reply, or {"0-0", {}} when the group is gone.
+var fencedAutoClaimScript = redis.NewScript(`
+local state = redis.call("HGET", KEYS[1], "state")
+if state ~= "active" then
+   return redis.error_reply("STREAMDESTROYED stream was destroyed")
+end
+` + leaseCheckLua + `
+local res = redis.pcall("XAUTOCLAIM", KEYS[3], ARGV[4], ARGV[5], ARGV[6], ARGV[7], "COUNT", ARGV[8])
+if type(res) == "table" and res["err"] then
+   if string.find(res["err"], "NOGROUP", 1, true) then
+      return {"0-0", {}}
+   end
+   return res
+end
+return res
+`)
+
+// fencedCleanupScript renews the lease and deletes stale consumers in one
+// atomic operation. A consumer is stale when it has no pending events and its
+// keep-alive is missing or older than the staleness threshold; its membership
+// map entry and keep-alive record are removed with rmap protocol
+// notifications. The caller's live consumer is never deleted.
+//
+// KEYS: [1]=lifecycle [2]=lease [3]=stream [4]=membership content
+// [5]=membership channel [6]=keep-alive content [7]=keep-alive channel
+// ARGV: [1]=owner [2]=fence [3]=leaseMs [4]=group [5]=staleNs [6]=live consumer
+// Returns the deleted consumer names.
+var fencedCleanupScript = redis.NewScript(`
+local state = redis.call("HGET", KEYS[1], "state")
+if state ~= "active" then
+   return redis.error_reply("STREAMDESTROYED stream was destroyed")
+end
+` + leaseCheckLua + membershipRemoveLua + `
+local consumers = redis.pcall("XINFO", "CONSUMERS", KEYS[3], ARGV[4])
+if type(consumers) == "table" and consumers["err"] then
+   if string.find(consumers["err"], "NOGROUP", 1, true) then
+      return {}
+   end
+   return consumers
+end
+local now_ns = (t[1] * 1000000 + t[2]) * 1000
+local removed = {}
+for _, info in ipairs(consumers) do
+   local name, pending
+   for i = 1, #info, 2 do
+      if info[i] == "name" then name = info[i+1] end
+      if info[i] == "pending" then pending = info[i+1] end
+   end
+   if name ~= ARGV[6] and pending == 0 then
+      local ka = redis.call("HGET", KEYS[6], name)
+      if not ka or now_ns - tonumber(ka) > tonumber(ARGV[5]) then
+         redis.call("XGROUP", "DELCONSUMER", KEYS[3], ARGV[4], name)
+         if ka then
+            redis.call("HDEL", KEYS[6], name)
+            local rev = tostring(redis.call("HINCRBY", KEYS[6], "=rev", 1))
+            redis.call("HSET", KEYS[6], "=kind", "del")
+            local msg = struct.pack("ic0ic0", string.len(name), name, string.len(rev), rev)
+            redis.call("PUBLISH", KEYS[7], "del:" .. msg)
+         end
+         membership_remove(KEYS[4], KEYS[5], ARGV[4], name)
+         table.insert(removed, name)
+      end
+   end
+end
+return removed
+`)
+
+// acquireSinkLease attempts to acquire or renew the sink lease for the stream
+// using Redis time. It returns whether the lease is held and the fence value
+// to pass to subsequent fenced operations.
+func acquireSinkLease(ctx context.Context, stream *Stream, sinkName, owner string, leaseMs int64) (bool, int64, error) {
+	keys := []string{lifecycleKey(stream.key), leaseKey(stream.key, sinkName)}
+	res, err := acquireLeaseScript.Run(ctx, stream.rdb, keys, owner, leaseMs).Slice()
+	if err != nil {
+		if isStreamDestroyedErr(err) {
+			return false, 0, fmt.Errorf("cannot acquire lease for stream %s: %w", stream.Name, ErrStreamDestroyed)
+		}
+		return false, 0, fmt.Errorf("failed to acquire lease for stream %s: %w", stream.Name, err)
+	}
+	return res[0].(int64) == 1, res[1].(int64), nil
+}
+
+// fencedAutoClaim renews the lease and claims up to count messages idle for
+// at least minIdleMs, starting at start, assigning them to consumer. It
+// returns the claimed messages and the next XAUTOCLAIM start cursor ("0-0"
+// when the scan is complete).
+func fencedAutoClaim(ctx context.Context, stream *Stream, sinkName, owner string, fence, leaseMs int64, consumer string, minIdleMs int64, start string, count int64) ([]redis.XMessage, string, error) {
+	keys := []string{lifecycleKey(stream.key), leaseKey(stream.key, sinkName), stream.key}
+	res, err := fencedAutoClaimScript.Run(ctx, stream.rdb, keys,
+		owner, fence, leaseMs, sinkName, consumer, minIdleMs, start, count).Slice()
+	if err != nil {
+		return nil, "", err
+	}
+	next := res[0].(string)
+	entries, ok := res[1].([]any)
+	if !ok {
+		return nil, "", fmt.Errorf("unexpected XAUTOCLAIM entries type %T", res[1])
+	}
+	msgs, err := decodeClaimedMessages(entries)
+	if err != nil {
+		return nil, "", err
+	}
+	return msgs, next, nil
+}
+
+// fencedCleanupStaleConsumers renews the lease and deletes consumers of the
+// sink group that have no pending events and whose keep-alive is missing or
+// older than staleNs nanoseconds of Redis time. liveConsumer is the caller's
+// current consumer and is never deleted. It returns the deleted consumer
+// names.
+func fencedCleanupStaleConsumers(ctx context.Context, stream *Stream, sinkName, owner string, fence, leaseMs int64, staleNs int64, liveConsumer string) ([]string, error) {
+	keys := []string{
+		lifecycleKey(stream.key),
+		leaseKey(stream.key, sinkName),
+		stream.key,
+		membershipContentKey(stream.Name),
+		membershipChannelKey(stream.Name),
+		keepAliveContentKey(sinkName),
+		keepAliveChannelKey(sinkName),
+	}
+	res, err := fencedCleanupScript.Run(ctx, stream.rdb, keys,
+		owner, fence, leaseMs, sinkName, staleNs, liveConsumer).StringSlice()
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// decodeClaimedMessages converts the raw Lua XAUTOCLAIM entries reply into
+// XMessage values. Nil entries (tombstones of trimmed events reported by
+// older Redis servers) are skipped.
+func decodeClaimedMessages(entries []any) ([]redis.XMessage, error) {
+	msgs := make([]redis.XMessage, 0, len(entries))
+	for _, entry := range entries {
+		if entry == nil {
+			continue
+		}
+		pair, ok := entry.([]any)
+		if !ok || len(pair) != 2 {
+			return nil, fmt.Errorf("unexpected XAUTOCLAIM entry %v", entry)
+		}
+		id, ok := pair[0].(string)
+		if !ok {
+			return nil, fmt.Errorf("unexpected XAUTOCLAIM entry ID %v", pair[0])
+		}
+		fields, ok := pair[1].([]any)
+		if !ok || len(fields)%2 != 0 {
+			return nil, fmt.Errorf("unexpected XAUTOCLAIM entry fields %v", pair[1])
+		}
+		values := make(map[string]any, len(fields)/2)
+		for i := 0; i < len(fields); i += 2 {
+			key, ok := fields[i].(string)
+			if !ok {
+				return nil, fmt.Errorf("unexpected XAUTOCLAIM field name %v", fields[i])
+			}
+			values[key] = fields[i+1]
+		}
+		msgs = append(msgs, redis.XMessage{ID: id, Values: values})
+	}
+	return msgs, nil
+}
+
+// isLeaseLostErr reports whether err is the fenced-script rejection of an
+// operation whose lease was taken over by another sink instance.
+func isLeaseLostErr(err error) bool {
+	return err != nil && strings.HasPrefix(err.Error(), leaseLostErrorPrefix)
+}
+
+// keepAliveContentKey returns the rmap content key of the sink keep-alive map
+// (see sinkKeepAliveMapName).
+func keepAliveContentKey(sinkName string) string {
+	return fmt.Sprintf("map:sink:%s:keepalive:content", sinkName)
+}
+
+// keepAliveChannelKey returns the rmap pubsub channel of the sink keep-alive
+// map.
+func keepAliveChannelKey(sinkName string) string {
+	return fmt.Sprintf("map:sink:%s:keepalive:updates", sinkName)
+}

--- a/streaming/sink_recovery.go
+++ b/streaming/sink_recovery.go
@@ -1,0 +1,484 @@
+// This file implements lossless consumer-group recovery and the stream
+// lifecycle fence shared by sinks and Stream.Destroy.
+//
+// Every piece of durable sink metadata attached to a stream lives under the
+// "pulse:streammeta:<stream>" prefix:
+//
+//   - <prefix>:lifecycle  hash with a "state" field ("active" or "destroyed").
+//   - <prefix>:cursors    hash mapping sink name to the recovery cursor, the
+//     highest event ID known to be fully acknowledged for that sink.
+//   - <prefix>:sink:<sink>:lease  fenced lease used by sink_lease.go.
+//
+// The lifecycle hash is the destroy fence: every Lua script in this file and
+// in sink_lease.go that mutates stream-scoped metadata reads the lifecycle
+// state first, inside the same atomic script invocation as the write. Once
+// Stream.Destroy marks a stream destroyed no concurrent sink loop can
+// recreate its consumer group, membership map, cursor, or lease; only a
+// deliberate NewSink/AddStream call (establish mode) reactivates the name.
+//
+// The recovery cursor is what makes NOGROUP recovery lossless: when a
+// consumer group disappears (XGROUP DESTROY, Redis state loss) the group is
+// recreated at the stored cursor rather than "$" so unacknowledged events are
+// redelivered. The cursor is advanced by recomputing it from the exact PEL
+// state each time events are acknowledged.
+//
+// Scripts publish replicated-map updates using the exact rmap wire protocol
+// (see rmap/scripts.go) so live rmap clients observe fenced membership
+// mutations exactly as if they had been made through the rmap API.
+package streaming
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	redis "github.com/redis/go-redis/v9"
+)
+
+type (
+	// recoveryAcker acknowledges sink events and atomically advances the
+	// durable recovery cursor from the exact PEL state. It is the Acker
+	// carried by every event delivered through a sink, so both Sink.Ack and
+	// direct Event.Acker.XAck calls keep the recovery cursor current.
+	recoveryAcker struct {
+		rdb *redis.Client
+	}
+)
+
+var (
+	// ErrStreamDestroyed is returned when a sink operation targets a stream
+	// that was destroyed with Stream.Destroy. The sink drops the stream from
+	// its set instead of resurrecting its metadata.
+	ErrStreamDestroyed = errors.New("stream is destroyed")
+
+	// ErrSinkClosed is returned by AddStream and RemoveStream after Close.
+	ErrSinkClosed = errors.New("sink is closed")
+)
+
+// streamDestroyedErrorPrefix is the Redis error prefix used by fenced scripts
+// to reject writes against a destroyed stream.
+const streamDestroyedErrorPrefix = "STREAMDESTROYED"
+
+// lifecycleFenceLua guards a script against destroyed streams and activates
+// absent lifecycles. Scripts using it must bind KEYS[1] to the lifecycle key
+// and define an `establish` local ("1" reactivates a destroyed stream).
+const lifecycleFenceLua = `
+local state = redis.call("HGET", KEYS[1], "state")
+if state == "destroyed" then
+   if establish == "1" then
+      redis.call("HSET", KEYS[1], "state", "active")
+   else
+      return redis.error_reply("STREAMDESTROYED stream was destroyed")
+   end
+elseif not state then
+   redis.call("HSET", KEYS[1], "state", "active")
+end
+`
+
+// recoveryCursorLua defines recovery_cursor(stream, group) which computes the
+// highest event ID X such that every entry at or before X is acknowledged:
+// the entry preceding the oldest pending entry when the PEL is not empty, the
+// group last-delivered-id otherwise. Returns false when the group is gone.
+const recoveryCursorLua = `
+local function recovery_cursor(stream, group)
+   local pending = redis.pcall("XPENDING", stream, group)
+   if pending["err"] then
+      return false
+   end
+   if pending[1] > 0 then
+      local prev = redis.call("XREVRANGE", stream, "(" .. pending[2], "-", "COUNT", 1)
+      if #prev == 0 then
+         return "0-0"
+      end
+      return prev[1][1]
+   end
+   local groups = redis.call("XINFO", "GROUPS", stream)
+   for _, info in ipairs(groups) do
+      local name, last
+      for i = 1, #info, 2 do
+         if info[i] == "name" then name = info[i+1] end
+         if info[i] == "last-delivered-id" then last = info[i+1] end
+      end
+      if name == group then
+         return last
+      end
+   end
+   return false
+end
+`
+
+// membershipRemoveLua defines membership_remove(content, channel, field,
+// value) which removes value from the JSON-array field of an rmap content
+// hash and publishes the matching rmap protocol notification.
+const membershipRemoveLua = `
+local function membership_remove(content, channel, field, value)
+   local v = redis.call("HGET", content, field)
+   if not v then
+      return
+   end
+   local values = {}
+   local ok, decoded = pcall(cjson.decode, v)
+   if ok and type(decoded) == "table" then
+      values = decoded
+   else
+      for s in string.gmatch(v, "[^,]+") do
+         table.insert(values, s)
+      end
+   end
+   local remaining = {}
+   local removed = false
+   for _, item in ipairs(values) do
+      if item == value then
+         removed = true
+      else
+         table.insert(remaining, item)
+      end
+   end
+   if not removed then
+      return
+   end
+   if #remaining == 0 then
+      redis.call("HDEL", content, field)
+      local rev = tostring(redis.call("HINCRBY", content, "=rev", 1))
+      redis.call("HSET", content, "=kind", "del")
+      local msg = struct.pack("ic0ic0", string.len(field), field, string.len(rev), rev)
+      redis.call("PUBLISH", channel, "del:" .. msg)
+      return
+   end
+   local encoded = cjson.encode(remaining)
+   redis.call("HSET", content, field, encoded)
+   local rev = tostring(redis.call("HINCRBY", content, "=rev", 1))
+   redis.call("HSET", content, "=kind", "set")
+   local msg = struct.pack("ic0ic0ic0", string.len(field), field, string.len(encoded), encoded, string.len(rev), rev)
+   redis.call("PUBLISH", channel, "set:" .. msg)
+end
+`
+
+// ensureConsumerGroupScript creates or repairs the consumer group for a sink
+// behind the lifecycle fence and restores the stream TTL even when the group
+// already exists (BUSYGROUP). The group is created at the durable recovery
+// cursor when one exists, at the caller start ID otherwise, and the cursor is
+// recomputed and stored from live group state so it is always defined.
+//
+// KEYS: [1]=lifecycle [2]=stream [3]=cursors
+// ARGV: [1]=group [2]=startID [3]=establish [4]=ttlMs [5]=ttlSliding
+// Returns {created(0|1), cursor}.
+var ensureConsumerGroupScript = redis.NewScript(`
+local establish = ARGV[3]
+` + lifecycleFenceLua + recoveryCursorLua + `
+local start = redis.call("HGET", KEYS[3], ARGV[1])
+if not start then
+   start = ARGV[2]
+end
+local created = 1
+local res = redis.pcall("XGROUP", "CREATE", KEYS[2], ARGV[1], start, "MKSTREAM")
+if type(res) == "table" and res["err"] then
+   if not string.find(res["err"], "BUSYGROUP", 1, true) then
+      return res
+   end
+   created = 0
+end
+local cursor = recovery_cursor(KEYS[2], ARGV[1])
+redis.call("HSET", KEYS[3], ARGV[1], cursor)
+if tonumber(ARGV[4]) > 0 then
+   if ARGV[5] == "1" then
+      redis.call("PEXPIRE", KEYS[2], ARGV[4])
+   else
+      redis.call("PEXPIRE", KEYS[2], ARGV[4], "NX")
+   end
+end
+return {created, cursor}
+`)
+
+// ackEventsScript acknowledges events and atomically advances the recovery
+// cursor from the exact PEL state. Acking events of a destroyed stream or of
+// a deleted group is a no-op returning 0, matching XACK semantics on missing
+// keys.
+//
+// KEYS: [1]=lifecycle [2]=stream [3]=cursors
+// ARGV: [1]=group [2..]=event IDs
+var ackEventsScript = redis.NewScript(`
+local state = redis.call("HGET", KEYS[1], "state")
+if state ~= "active" then
+   return 0
+end
+` + recoveryCursorLua + `
+local acked = redis.call("XACK", KEYS[2], ARGV[1], unpack(ARGV, 2))
+local cursor = recovery_cursor(KEYS[2], ARGV[1])
+if cursor then
+   redis.call("HSET", KEYS[3], ARGV[1], cursor)
+end
+return acked
+`)
+
+// registerConsumerScript creates a Redis consumer in the sink group and
+// appends it to the stream membership map behind the lifecycle fence, in one
+// atomic operation so membership and consumer-group state cannot diverge.
+//
+// KEYS: [1]=lifecycle [2]=stream [3]=membership content [4]=membership channel
+// ARGV: [1]=group [2]=consumer
+var registerConsumerScript = redis.NewScript(`
+local state = redis.call("HGET", KEYS[1], "state")
+if state ~= "active" then
+   return redis.error_reply("STREAMDESTROYED stream was destroyed")
+end
+local res = redis.pcall("XGROUP", "CREATECONSUMER", KEYS[2], ARGV[1], ARGV[2])
+if type(res) == "table" and res["err"] then
+   return res
+end
+local field = ARGV[1]
+local v = redis.call("HGET", KEYS[3], field)
+local values = {}
+if v then
+   local ok, decoded = pcall(cjson.decode, v)
+   if ok and type(decoded) == "table" then
+      values = decoded
+   else
+      for s in string.gmatch(v, "[^,]+") do
+         table.insert(values, s)
+      end
+   end
+end
+for _, item in ipairs(values) do
+   if item == ARGV[2] then
+      return 1
+   end
+end
+table.insert(values, ARGV[2])
+local encoded = cjson.encode(values)
+redis.call("HSET", KEYS[3], field, encoded)
+local rev = tostring(redis.call("HINCRBY", KEYS[3], "=rev", 1))
+redis.call("HSET", KEYS[3], "=kind", "set")
+local msg = struct.pack("ic0ic0ic0", string.len(field), field, string.len(encoded), encoded, string.len(rev), rev)
+redis.call("PUBLISH", KEYS[4], "set:" .. msg)
+return 1
+`)
+
+// detachConsumerScript rolls back a consumer registration: it removes the
+// consumer from the membership map and deletes the Redis consumer when its
+// PEL is empty. Used to compensate partial consumer rotation. A destroyed
+// stream has no metadata left to detach so the script is then a no-op.
+//
+// KEYS: [1]=lifecycle [2]=stream [3]=membership content [4]=membership channel
+// ARGV: [1]=group [2]=consumer
+var detachConsumerScript = redis.NewScript(`
+local state = redis.call("HGET", KEYS[1], "state")
+if state ~= "active" then
+   return 0
+end
+` + membershipRemoveLua + `
+local pending = redis.pcall("XPENDING", KEYS[2], ARGV[1], "-", "+", 1, ARGV[2])
+if not pending["err"] and #pending == 0 then
+   redis.call("XGROUP", "DELCONSUMER", KEYS[2], ARGV[1], ARGV[2])
+end
+membership_remove(KEYS[3], KEYS[4], ARGV[1], ARGV[2])
+return 1
+`)
+
+// removeSinkStreamScript atomically removes a sink consumer from the stream
+// membership map and, when it was the last member, destroys the consumer
+// group, its recovery cursor, and its lease. Being a single script there is
+// no partial failure between membership and group state to compensate.
+//
+// KEYS: [1]=lifecycle [2]=stream [3]=cursors [4]=membership content
+// [5]=membership channel [6]=lease
+// ARGV: [1]=group [2]=consumer
+var removeSinkStreamScript = redis.NewScript(`
+local state = redis.call("HGET", KEYS[1], "state")
+if state ~= "active" then
+   return 1
+end
+` + membershipRemoveLua + `
+membership_remove(KEYS[4], KEYS[5], ARGV[1], ARGV[2])
+if not redis.call("HGET", KEYS[4], ARGV[1]) then
+   redis.call("XGROUP", "DESTROY", KEYS[2], ARGV[1])
+   redis.call("HDEL", KEYS[3], ARGV[1])
+   redis.call("DEL", KEYS[6])
+end
+return 1
+`)
+
+// destroyStreamScript marks the stream destroyed and deletes every key owned
+// by the stream in one atomic operation: events, recovery cursors, sink
+// leases (enumerated from the membership map fields), and the membership map
+// itself via the rmap destroy protocol. The lifecycle hash is kept as the
+// destroyed tombstone that fences concurrent sink metadata writes.
+//
+// KEYS: [1]=lifecycle [2]=stream [3]=cursors [4]=membership content
+// [5]=membership channel
+// ARGV: [1]=lease key prefix (lease key is prefix .. sink .. ":lease")
+var destroyStreamScript = redis.NewScript(`
+redis.call("HSET", KEYS[1], "state", "destroyed")
+redis.call("DEL", KEYS[2], KEYS[3])
+if redis.call("EXISTS", KEYS[4]) == 1 then
+   for _, field in ipairs(redis.call("HKEYS", KEYS[4])) do
+      if field ~= "=rev" and field ~= "=kind" then
+         redis.call("DEL", ARGV[1] .. field .. ":lease")
+      end
+   end
+   local rev = redis.call("HINCRBY", KEYS[4], "=rev", 1)
+   redis.call("DEL", KEYS[4])
+   redis.call("HSET", KEYS[4], "=rev", rev, "=kind", "destroy")
+   redis.call("PUBLISH", KEYS[5], "destroy:" .. tostring(rev))
+end
+return 1
+`)
+
+// ensureConsumerGroup creates or repairs the consumer group for sinkName on
+// stream at the durable recovery cursor (startID for brand new groups) and
+// restores the stream TTL. establish reactivates a destroyed stream and is
+// reserved for deliberate NewSink/AddStream calls; recovery paths pass false
+// so a destroyed stream fails with ErrStreamDestroyed instead of being
+// resurrected. Returns whether the group was created and the stored cursor.
+func ensureConsumerGroup(ctx context.Context, stream *Stream, sinkName, startID string, establish bool) (bool, string, error) {
+	keys := []string{lifecycleKey(stream.key), stream.key, cursorsKey(stream.key)}
+	args := []any{sinkName, startID, boolArg(establish), stream.ttl.Milliseconds(), boolArg(stream.ttlSliding)}
+	res, err := ensureConsumerGroupScript.Run(ctx, stream.rdb, keys, args...).Slice()
+	if err != nil {
+		if isStreamDestroyedErr(err) {
+			return false, "", fmt.Errorf("cannot create consumer group %s for stream %s: %w", sinkName, stream.Name, ErrStreamDestroyed)
+		}
+		return false, "", fmt.Errorf("failed to create consumer group %s for stream %s: %w", sinkName, stream.Name, err)
+	}
+	return res[0].(int64) == 1, res[1].(string), nil
+}
+
+// registerSinkConsumer atomically creates the Redis consumer for sinkName in
+// the stream consumer group and records it in the stream membership map.
+func registerSinkConsumer(ctx context.Context, stream *Stream, sinkName, consumer string) error {
+	keys := []string{
+		lifecycleKey(stream.key),
+		stream.key,
+		membershipContentKey(stream.Name),
+		membershipChannelKey(stream.Name),
+	}
+	if err := registerConsumerScript.Run(ctx, stream.rdb, keys, sinkName, consumer).Err(); err != nil {
+		if isStreamDestroyedErr(err) {
+			return fmt.Errorf("cannot register consumer %s for stream %s: %w", consumer, stream.Name, ErrStreamDestroyed)
+		}
+		return fmt.Errorf("failed to register consumer %s for stream %s: %w", consumer, stream.Name, err)
+	}
+	return nil
+}
+
+// detachSinkConsumer compensates a partial consumer rotation by removing the
+// consumer from the stream membership map and deleting the Redis consumer
+// when it has no pending events.
+func detachSinkConsumer(ctx context.Context, stream *Stream, sinkName, consumer string) error {
+	keys := []string{
+		lifecycleKey(stream.key),
+		stream.key,
+		membershipContentKey(stream.Name),
+		membershipChannelKey(stream.Name),
+	}
+	if err := detachConsumerScript.Run(ctx, stream.rdb, keys, sinkName, consumer).Err(); err != nil {
+		return fmt.Errorf("failed to detach consumer %s from stream %s: %w", consumer, stream.Name, err)
+	}
+	return nil
+}
+
+// removeSinkStream removes the sink consumer from the stream membership map
+// and destroys the consumer group, recovery cursor, and lease when the
+// consumer was the last member, all in one atomic operation.
+func removeSinkStream(ctx context.Context, stream *Stream, sinkName, consumer string) error {
+	keys := []string{
+		lifecycleKey(stream.key),
+		stream.key,
+		cursorsKey(stream.key),
+		membershipContentKey(stream.Name),
+		membershipChannelKey(stream.Name),
+		leaseKey(stream.key, sinkName),
+	}
+	if err := removeSinkStreamScript.Run(ctx, stream.rdb, keys, sinkName, consumer).Err(); err != nil {
+		return fmt.Errorf("failed to remove sink %s from stream %s: %w", sinkName, stream.Name, err)
+	}
+	return nil
+}
+
+// destroyStream atomically marks the stream destroyed and deletes its events
+// and sink metadata. It is idempotent and safe to call on streams that were
+// never created.
+func destroyStream(ctx context.Context, stream *Stream) error {
+	keys := []string{
+		lifecycleKey(stream.key),
+		stream.key,
+		cursorsKey(stream.key),
+		membershipContentKey(stream.Name),
+		membershipChannelKey(stream.Name),
+	}
+	return destroyStreamScript.Run(ctx, stream.rdb, keys, leaseKeyPrefix(stream.key)).Err()
+}
+
+// XAck acknowledges the events and advances the sink recovery cursor from the
+// exact PEL state in one atomic operation. It satisfies the Acker interface
+// so acknowledging a sink event through Event.Acker keeps recovery lossless.
+func (a *recoveryAcker) XAck(ctx context.Context, streamKey, sinkName string, ids ...string) *redis.IntCmd {
+	cmd := redis.NewIntCmd(ctx)
+	keys := []string{lifecycleKey(streamKey), streamKey, cursorsKey(streamKey)}
+	args := make([]any, 0, len(ids)+1)
+	args = append(args, sinkName)
+	for _, id := range ids {
+		args = append(args, id)
+	}
+	acked, err := ackEventsScript.Run(ctx, a.rdb, keys, args...).Int64()
+	if err != nil {
+		cmd.SetErr(err)
+		return cmd
+	}
+	cmd.SetVal(acked)
+	return cmd
+}
+
+// streamMetaPrefix returns the metadata key prefix for the stream with the
+// given event key. Metadata lives under a prefix distinct from the event key
+// so stream names cannot collide with metadata key suffixes.
+func streamMetaPrefix(streamKey string) string {
+	return "pulse:streammeta:" + streamKey[len(streamKeyPrefix):]
+}
+
+// lifecycleKey returns the lifecycle fence key for the stream event key.
+func lifecycleKey(streamKey string) string {
+	return streamMetaPrefix(streamKey) + ":lifecycle"
+}
+
+// cursorsKey returns the recovery cursor hash key for the stream event key.
+func cursorsKey(streamKey string) string {
+	return streamMetaPrefix(streamKey) + ":cursors"
+}
+
+// leaseKeyPrefix returns the prefix of per-sink lease keys for the stream.
+func leaseKeyPrefix(streamKey string) string {
+	return streamMetaPrefix(streamKey) + ":sink:"
+}
+
+// leaseKey returns the fenced lease key for the sink on the stream.
+func leaseKey(streamKey, sinkName string) string {
+	return leaseKeyPrefix(streamKey) + sinkName + ":lease"
+}
+
+// membershipContentKey returns the rmap content key of the stream sink
+// membership map (see consumersMapName).
+func membershipContentKey(streamName string) string {
+	return fmt.Sprintf("map:stream:%s:sinks:content", streamName)
+}
+
+// membershipChannelKey returns the rmap pubsub channel of the stream sink
+// membership map.
+func membershipChannelKey(streamName string) string {
+	return fmt.Sprintf("map:stream:%s:sinks:updates", streamName)
+}
+
+// isStreamDestroyedErr reports whether err is the fenced-script rejection of
+// a write against a destroyed stream.
+func isStreamDestroyedErr(err error) bool {
+	return err != nil && strings.HasPrefix(err.Error(), streamDestroyedErrorPrefix)
+}
+
+// boolArg encodes a boolean as the "0"/"1" convention used by the scripts.
+func boolArg(b bool) string {
+	if b {
+		return "1"
+	}
+	return "0"
+}

--- a/streaming/sink_recovery_test.go
+++ b/streaming/sink_recovery_test.go
@@ -418,6 +418,53 @@ func TestDestroyFencesSinkMetadataWrites(t *testing.T) {
 	assert.Equal(t, "destroyed", rdb.HGet(ctx, lifecycleKey(s.key), "state").Val())
 }
 
+// TestDispatchLeavesRemovedStreamEventsPending verifies that a batch read for
+// a stream removed from this sink concurrently with the read is left pending
+// for the surviving group members instead of being acknowledged undelivered,
+// which would permanently drop the events for the whole group.
+func TestDispatchLeavesRemovedStreamEventsPending(t *testing.T) {
+	testName := strings.Replace(t.Name(), "/", "_", -1)
+	rdb := ptesting.NewRedisClient(t)
+	defer ptesting.CleanupRedis(t, rdb, true, testName)
+	ctx := ptesting.NewTestContext(t)
+	s, err := NewStream(testName, rdb, options.WithStreamLogger(pulse.ClueLogger(ctx)))
+	require.NoError(t, err)
+	removed, err := s.NewSink(ctx, "sink",
+		options.WithSinkStartAtOldest(),
+		options.WithSinkBlockDuration(testBlockDuration))
+	require.NoError(t, err)
+	defer removed.Close(ctx)
+	s2, err := NewStream(testName, ptesting.NewRedisClient(t), options.WithStreamLogger(pulse.ClueLogger(ctx)))
+	require.NoError(t, err)
+	survivor, err := s2.NewSink(ctx, "sink",
+		options.WithSinkStartAtOldest(),
+		options.WithSinkBlockDuration(testBlockDuration))
+	require.NoError(t, err)
+	defer cleanupSink(t, ctx, s2, survivor)
+
+	// Drop the stream from one sink; the group survives through the other
+	// member. Wait out reads issued before the removal so the event below is
+	// deterministically delivered to the survivor's consumer PEL, unacked.
+	c := survivor.Subscribe()
+	require.NoError(t, removed.RemoveStream(ctx, s))
+	time.Sleep(3 * testBlockDuration)
+	id, err := s.Add(ctx, "event", []byte("payload"))
+	require.NoError(t, err)
+	ev := receiveEvent(t, c)
+	require.Equal(t, id, ev.ID)
+
+	// Replay the racing batch against the sink that no longer owns the
+	// stream: dispatch must not settle the group's pending entry.
+	require.NoError(t, removed.dispatch([]redis.XStream{{
+		Stream:   s.key,
+		Messages: []redis.XMessage{{ID: id, Values: map[string]any{nameKey: "event", payloadKey: "payload"}}},
+	}}))
+	pending, err := rdb.XPending(ctx, s.key, "sink").Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), pending.Count, "unowned batch must stay pending for surviving members")
+	require.NoError(t, survivor.Ack(ctx, ev))
+}
+
 // TestSinkAcknowledgesFilteredEvents verifies that events dropped by the sink
 // topic filter are acknowledged so they cannot hold back the recovery cursor.
 func TestSinkAcknowledgesFilteredEvents(t *testing.T) {

--- a/streaming/sink_recovery_test.go
+++ b/streaming/sink_recovery_test.go
@@ -1,0 +1,678 @@
+// Tests for lossless consumer group recovery, the destroy lifecycle fence,
+// fenced leases, close semantics, and failure-atomic stream ownership
+// changes. All tests run against a live Redis instance.
+package streaming
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	redis "github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"goa.design/pulse/pulse"
+	"goa.design/pulse/streaming/options"
+	ptesting "goa.design/pulse/testing"
+)
+
+// TestSinkRecoversGroupAfterExternalDestroy is the core lossless recovery
+// scenario: publish events, ack some, force XGROUP DESTROY, and verify the
+// group is recreated at the recovery cursor so every unacked event is
+// redelivered exactly once and no acked event is redelivered.
+func TestSinkRecoversGroupAfterExternalDestroy(t *testing.T) {
+	testName := strings.Replace(t.Name(), "/", "_", -1)
+	rdb := ptesting.NewRedisClient(t)
+	defer ptesting.CleanupRedis(t, rdb, true, testName)
+	ctx := ptesting.NewTestContext(t)
+	s, err := NewStream(testName, rdb, options.WithStreamLogger(pulse.ClueLogger(ctx)))
+	require.NoError(t, err)
+	sink, err := s.NewSink(ctx, "sink",
+		options.WithSinkStartAtOldest(),
+		options.WithSinkBlockDuration(testBlockDuration))
+	require.NoError(t, err)
+	defer cleanupSink(t, ctx, s, sink)
+
+	c := sink.Subscribe()
+	ids := make([]string, 5)
+	for i := range ids {
+		ids[i], err = s.Add(ctx, fmt.Sprintf("event%d", i), []byte("payload"))
+		require.NoError(t, err)
+	}
+	events := make([]*Event, 5)
+	for i := range events {
+		events[i] = receiveEvent(t, c)
+	}
+	require.NoError(t, sink.Ack(ctx, events[0]))
+	require.NoError(t, sink.Ack(ctx, events[1]))
+	// Acks advance the recovery cursor synchronously.
+	assert.Equal(t, ids[1], recoveryCursor(t, ctx, rdb, s, "sink"))
+
+	// Simulate Redis consumer group state loss.
+	require.NoError(t, rdb.XGroupDestroy(ctx, s.key, "sink").Err())
+	futureID, err := s.Add(ctx, "future", []byte("payload"))
+	require.NoError(t, err)
+
+	// Every unacked event and the new event must be redelivered exactly once.
+	var redelivered []string
+	for range 4 {
+		ev := receiveEvent(t, c)
+		redelivered = append(redelivered, ev.ID)
+		require.NoError(t, sink.Ack(ctx, ev))
+	}
+	assert.Equal(t, []string{ids[2], ids[3], ids[4], futureID}, redelivered)
+	select {
+	case ev := <-c:
+		t.Errorf("unexpected redelivery of event %s", ev.ID)
+	case <-time.After(4 * testBlockDuration):
+	}
+	groups, err := rdb.XInfoGroups(ctx, s.key).Result()
+	require.NoError(t, err)
+	require.Len(t, groups, 1)
+	assert.Equal(t, "sink", groups[0].Name)
+}
+
+// TestSinkRecoveryCursorIsSharedAcrossReplicas verifies that sink replicas
+// share one durable recovery cursor per stream and group so whichever replica
+// recovers first resumes from the same acknowledged position.
+func TestSinkRecoveryCursorIsSharedAcrossReplicas(t *testing.T) {
+	testName := strings.Replace(t.Name(), "/", "_", -1)
+	rdb := ptesting.NewRedisClient(t)
+	defer ptesting.CleanupRedis(t, rdb, true, testName)
+	ctx := ptesting.NewTestContext(t)
+	s, err := NewStream(testName, rdb, options.WithStreamLogger(pulse.ClueLogger(ctx)))
+	require.NoError(t, err)
+	sink1, err := s.NewSink(ctx, "sink",
+		options.WithSinkStartAtOldest(),
+		options.WithSinkBlockDuration(testBlockDuration))
+	require.NoError(t, err)
+	defer cleanupSink(t, ctx, s, sink1)
+	sink2, err := s.NewSink(ctx, "sink",
+		options.WithSinkStartAtOldest(),
+		options.WithSinkBlockDuration(testBlockDuration))
+	require.NoError(t, err)
+	defer sink2.Close(ctx)
+
+	c1, c2 := sink1.Subscribe(), sink2.Subscribe()
+	ids := make([]string, 2)
+	for i := range ids {
+		ids[i], err = s.Add(ctx, fmt.Sprintf("event%d", i), []byte("payload"))
+		require.NoError(t, err)
+	}
+	for range ids {
+		select {
+		case ev := <-c1:
+			require.NoError(t, sink1.Ack(ctx, ev))
+		case ev := <-c2:
+			require.NoError(t, sink2.Ack(ctx, ev))
+		case <-time.After(max):
+			t.Fatal("timeout waiting for event")
+		}
+	}
+	assert.Equal(t, ids[1], recoveryCursor(t, ctx, rdb, s, "sink"))
+
+	require.NoError(t, rdb.XGroupDestroy(ctx, s.key, "sink").Err())
+	futureID, err := s.Add(ctx, "future", []byte("payload"))
+	require.NoError(t, err)
+
+	// Whichever replica recovers, only the new event is delivered.
+	select {
+	case ev := <-c1:
+		assert.Equal(t, futureID, ev.ID)
+		require.NoError(t, sink1.Ack(ctx, ev))
+	case ev := <-c2:
+		assert.Equal(t, futureID, ev.ID)
+		require.NoError(t, sink2.Ack(ctx, ev))
+	case <-time.After(max):
+		t.Fatal("timeout waiting for post-recovery event")
+	}
+	select {
+	case ev := <-c1:
+		t.Errorf("unexpected redelivery of event %s", ev.ID)
+	case ev := <-c2:
+		t.Errorf("unexpected redelivery of event %s", ev.ID)
+	case <-time.After(4 * testBlockDuration):
+	}
+}
+
+// TestEnsureGroupRestoresTTLOnBusyGroup verifies that ensuring an existing
+// consumer group (BUSYGROUP path) restores the stream TTL and that recovery
+// metadata itself never carries a TTL.
+func TestEnsureGroupRestoresTTLOnBusyGroup(t *testing.T) {
+	testName := strings.Replace(t.Name(), "/", "_", -1)
+	rdb := ptesting.NewRedisClient(t)
+	defer ptesting.CleanupRedis(t, rdb, true, testName)
+	ctx := ptesting.NewTestContext(t)
+	s, err := NewStream(testName, rdb,
+		options.WithStreamLogger(pulse.ClueLogger(ctx)),
+		options.WithStreamTTL(time.Hour))
+	require.NoError(t, err)
+	sink, err := s.NewSink(ctx, "sink",
+		options.WithSinkStartAtOldest(),
+		options.WithSinkBlockDuration(testBlockDuration))
+	require.NoError(t, err)
+	defer cleanupSink(t, ctx, s, sink)
+
+	_, err = s.Add(ctx, "event", []byte("payload"))
+	require.NoError(t, err)
+	require.NoError(t, rdb.Persist(ctx, s.key).Err())
+	require.Equal(t, time.Duration(-1), rdb.PTTL(ctx, s.key).Val())
+
+	created, _, err := ensureConsumerGroup(ctx, s, "sink", "$", false)
+	require.NoError(t, err)
+	assert.False(t, created, "group must already exist")
+	assert.Positive(t, rdb.PTTL(ctx, s.key).Val(), "stream TTL must be restored on BUSYGROUP")
+	assert.Equal(t, time.Duration(-1), rdb.PTTL(ctx, cursorsKey(s.key)).Val(),
+		"recovery cursors must outlive the event TTL")
+}
+
+// TestSinkRecoveryAfterEventStreamExpires verifies that when the Redis key
+// backing a TTL stream expires (deleting the consumer group with it), the
+// sink recreates the group from the durable recovery cursor and delivers
+// events published afterwards.
+func TestSinkRecoveryAfterEventStreamExpires(t *testing.T) {
+	testName := strings.Replace(t.Name(), "/", "_", -1)
+	rdb := ptesting.NewRedisClient(t)
+	defer ptesting.CleanupRedis(t, rdb, true, testName)
+	ctx := ptesting.NewTestContext(t)
+	s, err := NewStream(testName, rdb,
+		options.WithStreamLogger(pulse.ClueLogger(ctx)),
+		options.WithStreamTTL(500*time.Millisecond))
+	require.NoError(t, err)
+	sink, err := s.NewSink(ctx, "sink",
+		options.WithSinkStartAtOldest(),
+		options.WithSinkBlockDuration(testBlockDuration))
+	require.NoError(t, err)
+	defer cleanupSink(t, ctx, s, sink)
+
+	c := sink.Subscribe()
+	_, err = s.Add(ctx, "event", []byte("payload"))
+	require.NoError(t, err)
+	require.NoError(t, sink.Ack(ctx, receiveEvent(t, c)))
+
+	// Wait for the stream key (and with it the consumer group) to expire.
+	require.Eventually(t, func() bool {
+		return rdb.Exists(ctx, s.key).Val() == 0
+	}, 2*time.Second, delay)
+
+	futureID, err := s.Add(ctx, "future", []byte("payload"))
+	require.NoError(t, err)
+	ev := receiveEvent(t, c)
+	assert.Equal(t, futureID, ev.ID)
+	require.NoError(t, sink.Ack(ctx, ev))
+}
+
+// TestSinkCloseCancelsBlockingRedisRead verifies that Close cancels
+// sink-owned Redis I/O so a blocked XREADGROUP cannot stall shutdown.
+func TestSinkCloseCancelsBlockingRedisRead(t *testing.T) {
+	testName := strings.Replace(t.Name(), "/", "_", -1)
+	rdb := ptesting.NewRedisClient(t)
+	defer ptesting.CleanupRedis(t, rdb, true, testName)
+	ctx := ptesting.NewTestContext(t)
+	s, err := NewStream(testName, rdb, options.WithStreamLogger(pulse.ClueLogger(ctx)))
+	require.NoError(t, err)
+	hook := newRedisCommandHook()
+	rdb.AddHook(hook)
+	sink, err := s.NewSink(ctx, "sink",
+		options.WithSinkBlockDuration(time.Hour)) // would block Close without cancellation
+	require.NoError(t, err)
+
+	hook.blockRead.Store(true)
+	select {
+	case <-hook.readStarted:
+	case <-time.After(max):
+		t.Fatal("read loop never blocked on XREADGROUP")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		sink.Close(ctx)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close did not cancel the blocked Redis read")
+	}
+	assert.True(t, sink.IsClosed())
+	hook.blockRead.Store(false)
+	require.NoError(t, s.Destroy(ctx))
+}
+
+// TestSinkRejectsStreamMutationAfterClose verifies AddStream and RemoveStream
+// fail with ErrSinkClosed once Close was called.
+func TestSinkRejectsStreamMutationAfterClose(t *testing.T) {
+	testName := strings.Replace(t.Name(), "/", "_", -1)
+	rdb := ptesting.NewRedisClient(t)
+	defer ptesting.CleanupRedis(t, rdb, true, testName)
+	ctx := ptesting.NewTestContext(t)
+	s, err := NewStream(testName, rdb, options.WithStreamLogger(pulse.ClueLogger(ctx)))
+	require.NoError(t, err)
+	sink, err := s.NewSink(ctx, "sink", options.WithSinkBlockDuration(testBlockDuration))
+	require.NoError(t, err)
+	sink.Close(ctx)
+	require.True(t, sink.IsClosed())
+
+	s2, err := NewStream(testName+"2", rdb, options.WithStreamLogger(pulse.ClueLogger(ctx)))
+	require.NoError(t, err)
+	assert.ErrorIs(t, sink.AddStream(ctx, s2), ErrSinkClosed)
+	assert.ErrorIs(t, sink.RemoveStream(ctx, s), ErrSinkClosed)
+	require.NoError(t, s.Destroy(ctx))
+}
+
+// TestSinkAddStreamRollsBackPartialFailure verifies that a failed AddStream
+// compensates the consumer group and cursor it created so no dangling
+// ownership state survives, and that a subsequent AddStream succeeds.
+func TestSinkAddStreamRollsBackPartialFailure(t *testing.T) {
+	testName := strings.Replace(t.Name(), "/", "_", -1)
+	rdb := ptesting.NewRedisClient(t)
+	defer ptesting.CleanupRedis(t, rdb, true, testName)
+	ctx := ptesting.NewTestContext(t)
+	s, err := NewStream(testName, rdb, options.WithStreamLogger(pulse.ClueLogger(ctx)))
+	require.NoError(t, err)
+	s2, err := NewStream(testName+"2", rdb, options.WithStreamLogger(pulse.ClueLogger(ctx)))
+	require.NoError(t, err)
+	hook := newRedisCommandHook()
+	rdb.AddHook(hook)
+	sink, err := s.NewSink(ctx, "sink",
+		options.WithSinkStartAtOldest(),
+		options.WithSinkBlockDuration(testBlockDuration))
+	require.NoError(t, err)
+	defer cleanupSink(t, ctx, s, sink)
+	defer func() { assert.NoError(t, s2.Destroy(ctx)) }()
+
+	hook.failScript(registerConsumerScript.Hash(), s2.key)
+	require.Error(t, sink.AddStream(ctx, s2))
+	hook.clearFailure()
+
+	sink.lock.Lock()
+	_, owned := sink.streams[s2.key]
+	sink.lock.Unlock()
+	assert.False(t, owned, "failed AddStream must not leave the stream owned")
+	assert.Zero(t, rdb.Exists(ctx, cursorsKey(s2.key)).Val(), "compensation must delete the cursor")
+	groups, err := rdb.XInfoGroups(ctx, s2.key).Result()
+	require.NoError(t, err)
+	assert.Empty(t, groups, "compensation must delete the consumer group")
+
+	// AddStream succeeds once the failure clears.
+	require.NoError(t, sink.AddStream(ctx, s2))
+	c := sink.Subscribe()
+	_, err = s2.Add(ctx, "event", []byte("payload"))
+	require.NoError(t, err)
+	require.NoError(t, sink.Ack(ctx, receiveEvent(t, c)))
+}
+
+// TestSinkConsumerRotationRegistersEveryStreamOrRollsBack verifies that
+// replacement consumer creation is failure-atomic across all sink streams:
+// when registration fails for one stream the registrations already made are
+// detached so ownership state never diverges.
+func TestSinkConsumerRotationRegistersEveryStreamOrRollsBack(t *testing.T) {
+	testName := strings.Replace(t.Name(), "/", "_", -1)
+	rdb := ptesting.NewRedisClient(t)
+	defer ptesting.CleanupRedis(t, rdb, true, testName)
+	ctx := ptesting.NewTestContext(t)
+	s, err := NewStream(testName, rdb, options.WithStreamLogger(pulse.ClueLogger(ctx)))
+	require.NoError(t, err)
+	s2, err := NewStream(testName+"2", rdb, options.WithStreamLogger(pulse.ClueLogger(ctx)))
+	require.NoError(t, err)
+	hook := newRedisCommandHook()
+	rdb.AddHook(hook)
+	sink, err := s.NewSink(ctx, "sink",
+		options.WithSinkStartAtOldest(),
+		options.WithSinkBlockDuration(testBlockDuration))
+	require.NoError(t, err)
+	require.NoError(t, sink.AddStream(ctx, s2))
+	defer cleanupSink(t, ctx, s, sink)
+	defer func() { assert.NoError(t, s2.Destroy(ctx)) }()
+	original := sink.consumer
+
+	hook.failScript(registerConsumerScript.Hash(), s2.key)
+	sink.lock.Lock()
+	_, err = sink.newConsumer(ctx)
+	sink.lock.Unlock()
+	require.Error(t, err)
+	hook.clearFailure()
+
+	for _, stream := range []*Stream{s, s2} {
+		assert.Equal(t, []string{original}, memberConsumers(t, ctx, rdb, stream, "sink"),
+			"membership of %s must be unchanged after rollback", stream.Name)
+		assert.Equal(t, []string{original}, groupConsumers(t, ctx, rdb, stream, "sink"),
+			"consumer group of %s must be unchanged after rollback", stream.Name)
+	}
+
+	// Rotation succeeds once the failure clears and registers both streams.
+	sink.lock.Lock()
+	replacement, err := sink.newConsumer(ctx)
+	sink.lock.Unlock()
+	require.NoError(t, err)
+	for _, stream := range []*Stream{s, s2} {
+		assert.ElementsMatch(t, []string{original, replacement}, memberConsumers(t, ctx, rdb, stream, "sink"))
+	}
+}
+
+// TestDestroyFencesSinkMetadataWrites is the P1-A regression test: once
+// Stream.Destroy runs, a live sink (setup paths, replacement-consumer
+// creation, keepalive-driven loops, lease work) must not resurrect any
+// stream-scoped metadata.
+func TestDestroyFencesSinkMetadataWrites(t *testing.T) {
+	testName := strings.Replace(t.Name(), "/", "_", -1)
+	var origCheckIdlePeriod time.Duration
+	origCheckIdlePeriod, checkIdlePeriod = checkIdlePeriod, testCheckIdlePeriod
+	defer func() { checkIdlePeriod = origCheckIdlePeriod }()
+
+	rdb := ptesting.NewRedisClient(t)
+	defer ptesting.CleanupRedis(t, rdb, true, testName)
+	ctx := ptesting.NewTestContext(t)
+	s, err := NewStream(testName, rdb, options.WithStreamLogger(pulse.ClueLogger(ctx)))
+	require.NoError(t, err)
+	sink, err := s.NewSink(ctx, "sink",
+		options.WithSinkStartAtOldest(),
+		options.WithSinkBlockDuration(testBlockDuration),
+		options.WithSinkAckGracePeriod(testAckDuration))
+	require.NoError(t, err)
+	defer sink.Close(ctx)
+
+	c := sink.Subscribe()
+	_, err = s.Add(ctx, "event", []byte("payload"))
+	require.NoError(t, err)
+	require.NoError(t, sink.Ack(ctx, receiveEvent(t, c)))
+	require.Equal(t, int64(1), rdb.Exists(ctx, cursorsKey(s.key)).Val())
+
+	// Destroy the stream while the sink keepalive and idle-check loops are
+	// due to run.
+	require.NoError(t, s.Destroy(ctx))
+
+	// Every fenced metadata write must fail with ErrStreamDestroyed.
+	assert.ErrorIs(t, registerSinkConsumer(ctx, s, "sink", "ghost"), ErrStreamDestroyed)
+	_, _, err = ensureConsumerGroup(ctx, s, "sink", "$", false)
+	assert.ErrorIs(t, err, ErrStreamDestroyed)
+	_, _, err = acquireSinkLease(ctx, s, "sink", "ghost-owner", 1000)
+	assert.ErrorIs(t, err, ErrStreamDestroyed)
+
+	// The sink read loop observes NOGROUP, fails recovery with
+	// ErrStreamDestroyed, and drops the stream instead of resurrecting it.
+	assert.Eventually(t, func() bool {
+		sink.lock.Lock()
+		defer sink.lock.Unlock()
+		return len(sink.streams) == 0
+	}, max, delay, "sink must drop the destroyed stream")
+
+	// Let the periodic keepalive and idle-check loops tick several times,
+	// then verify no stream-scoped metadata was recreated.
+	time.Sleep(5 * testCheckIdlePeriod)
+	assert.Zero(t, rdb.Exists(ctx, s.key).Val(), "event stream must stay deleted")
+	assert.Zero(t, rdb.Exists(ctx, cursorsKey(s.key)).Val(), "recovery cursor must stay deleted")
+	assert.Zero(t, rdb.Exists(ctx, leaseKey(s.key, "sink")).Val(), "lease must stay deleted")
+	content, err := rdb.HGetAll(ctx, membershipContentKey(s.Name)).Result()
+	require.NoError(t, err)
+	assert.Equal(t, "destroy", content["=kind"], "membership map must remain a destroy tombstone")
+	assert.NotContains(t, content, "sink", "membership must not be resurrected")
+	assert.Equal(t, "destroyed", rdb.HGet(ctx, lifecycleKey(s.key), "state").Val())
+}
+
+// TestSinkAcknowledgesFilteredEvents verifies that events dropped by the sink
+// topic filter are acknowledged so they cannot hold back the recovery cursor.
+func TestSinkAcknowledgesFilteredEvents(t *testing.T) {
+	testName := strings.Replace(t.Name(), "/", "_", -1)
+	rdb := ptesting.NewRedisClient(t)
+	defer ptesting.CleanupRedis(t, rdb, true, testName)
+	ctx := ptesting.NewTestContext(t)
+	s, err := NewStream(testName, rdb, options.WithStreamLogger(pulse.ClueLogger(ctx)))
+	require.NoError(t, err)
+	sink, err := s.NewSink(ctx, "sink",
+		options.WithSinkStartAtOldest(),
+		options.WithSinkBlockDuration(testBlockDuration),
+		options.WithSinkTopic("keep"))
+	require.NoError(t, err)
+	defer cleanupSink(t, ctx, s, sink)
+
+	c := sink.Subscribe()
+	_, err = s.Add(ctx, "dropped", []byte("payload"), options.WithTopic("drop"))
+	require.NoError(t, err)
+	keepID, err := s.Add(ctx, "kept", []byte("payload"), options.WithTopic("keep"))
+	require.NoError(t, err)
+
+	ev := receiveEvent(t, c)
+	assert.Equal(t, keepID, ev.ID)
+	require.NoError(t, sink.Ack(ctx, ev))
+	assert.Equal(t, keepID, recoveryCursor(t, ctx, rdb, s, "sink"))
+	pending, err := rdb.XPending(ctx, s.key, "sink").Result()
+	require.NoError(t, err)
+	assert.Zero(t, pending.Count, "filtered events must be settled")
+}
+
+// TestSinkNoAckAdvancesRecoveryCursor verifies that NoAck sinks advance the
+// recovery cursor on delivery so recovery never replays delivered events.
+func TestSinkNoAckAdvancesRecoveryCursor(t *testing.T) {
+	testName := strings.Replace(t.Name(), "/", "_", -1)
+	rdb := ptesting.NewRedisClient(t)
+	defer ptesting.CleanupRedis(t, rdb, true, testName)
+	ctx := ptesting.NewTestContext(t)
+	s, err := NewStream(testName, rdb, options.WithStreamLogger(pulse.ClueLogger(ctx)))
+	require.NoError(t, err)
+	sink, err := s.NewSink(ctx, "sink",
+		options.WithSinkStartAtOldest(),
+		options.WithSinkBlockDuration(testBlockDuration),
+		options.WithSinkNoAck())
+	require.NoError(t, err)
+	defer cleanupSink(t, ctx, s, sink)
+
+	c := sink.Subscribe()
+	id, err := s.Add(ctx, "event", []byte("payload"))
+	require.NoError(t, err)
+	ev := receiveEvent(t, c)
+	assert.Equal(t, id, ev.ID)
+	assert.Equal(t, id, recoveryCursor(t, ctx, rdb, s, "sink"))
+
+	require.NoError(t, rdb.XGroupDestroy(ctx, s.key, "sink").Err())
+	futureID, err := s.Add(ctx, "future", []byte("payload"))
+	require.NoError(t, err)
+	ev = receiveEvent(t, c)
+	assert.Equal(t, futureID, ev.ID, "recovery must resume after the delivered event")
+	select {
+	case ev := <-c:
+		t.Errorf("unexpected redelivery of event %s", ev.ID)
+	case <-time.After(4 * testBlockDuration):
+	}
+}
+
+// TestEventAckerAdvancesRecoveryCursor verifies the cursor arithmetic of the
+// recovery acker: the cursor is always the entry preceding the oldest pending
+// event, and the group last-delivered-id once the PEL drains, even when
+// events are acknowledged out of order.
+func TestEventAckerAdvancesRecoveryCursor(t *testing.T) {
+	testName := strings.Replace(t.Name(), "/", "_", -1)
+	rdb := ptesting.NewRedisClient(t)
+	defer ptesting.CleanupRedis(t, rdb, true, testName)
+	ctx := ptesting.NewTestContext(t)
+	s, err := NewStream(testName, rdb, options.WithStreamLogger(pulse.ClueLogger(ctx)))
+	require.NoError(t, err)
+	sink, err := s.NewSink(ctx, "sink",
+		options.WithSinkStartAtOldest(),
+		options.WithSinkBlockDuration(testBlockDuration))
+	require.NoError(t, err)
+	defer cleanupSink(t, ctx, s, sink)
+
+	c := sink.Subscribe()
+	ids := make([]string, 3)
+	for i := range ids {
+		ids[i], err = s.Add(ctx, fmt.Sprintf("event%d", i), []byte("payload"))
+		require.NoError(t, err)
+	}
+	events := make(map[string]*Event, 3)
+	for range ids {
+		ev := receiveEvent(t, c)
+		events[ev.ID] = ev
+	}
+
+	// Ack out of order: the middle event first.
+	require.NoError(t, sink.Ack(ctx, events[ids[1]]))
+	assert.Equal(t, "0-0", recoveryCursor(t, ctx, rdb, s, "sink"),
+		"oldest pending event is the first entry so nothing is durably settled")
+	require.NoError(t, sink.Ack(ctx, events[ids[0]]))
+	assert.Equal(t, ids[1], recoveryCursor(t, ctx, rdb, s, "sink"),
+		"cursor must jump past the contiguous acknowledged prefix")
+	require.NoError(t, sink.Ack(ctx, events[ids[2]]))
+	assert.Equal(t, ids[2], recoveryCursor(t, ctx, rdb, s, "sink"),
+		"cursor must reach last-delivered-id once the PEL drains")
+}
+
+// TestReadRetryJitterBounds verifies the retry backoff is jittered between
+// half and full of the current backoff and doubles up to the cap.
+func TestReadRetryJitterBounds(t *testing.T) {
+	var r readRetry
+	expected := minReadRetryBackoff
+	for range 10 {
+		d := r.next()
+		assert.GreaterOrEqual(t, d, expected/2)
+		assert.LessOrEqual(t, d, expected)
+		expected = 2 * expected
+		if expected > maxReadRetryBackoff {
+			expected = maxReadRetryBackoff
+		}
+	}
+	r.reset()
+	d := r.next()
+	assert.GreaterOrEqual(t, d, minReadRetryBackoff/2)
+	assert.LessOrEqual(t, d, minReadRetryBackoff)
+}
+
+// receiveEvent reads one event from the channel without acknowledging it or
+// fails the test after the standard timeout.
+func receiveEvent(t *testing.T, c <-chan *Event) *Event {
+	t.Helper()
+	select {
+	case ev := <-c:
+		require.NotNil(t, ev)
+		return ev
+	case <-time.After(max):
+		t.Fatal("timeout waiting for event")
+		return nil
+	}
+}
+
+// recoveryCursor returns the durable recovery cursor stored for the sink on
+// the stream.
+func recoveryCursor(t *testing.T, ctx context.Context, rdb *redis.Client, s *Stream, sink string) string {
+	t.Helper()
+	cursor, err := rdb.HGet(ctx, cursorsKey(s.key), sink).Result()
+	require.NoError(t, err)
+	return cursor
+}
+
+// memberConsumers returns the consumer names recorded for the sink in the
+// stream membership map.
+func memberConsumers(t *testing.T, ctx context.Context, rdb *redis.Client, s *Stream, sink string) []string {
+	t.Helper()
+	raw, err := rdb.HGet(ctx, membershipContentKey(s.Name), sink).Result()
+	require.NoError(t, err)
+	var names []string
+	require.NoError(t, json.Unmarshal([]byte(raw), &names))
+	return names
+}
+
+// groupConsumers returns the Redis consumer names of the sink group on the
+// stream.
+func groupConsumers(t *testing.T, ctx context.Context, rdb *redis.Client, s *Stream, sink string) []string {
+	t.Helper()
+	consumers, err := rdb.XInfoConsumers(ctx, s.key, sink).Result()
+	require.NoError(t, err)
+	names := make([]string, len(consumers))
+	for i, c := range consumers {
+		names[i] = c.Name
+	}
+	return names
+}
+
+type (
+	// redisCommandHook injects command-specific failures and blocking reads
+	// into the sink Redis client to prove cancellation, bounded retries, and
+	// failure-atomic ownership changes.
+	redisCommandHook struct {
+		// blockRead blocks XREADGROUP calls until their context is canceled.
+		blockRead atomic.Bool
+		// readStarted is closed the first time a read blocks.
+		readStarted chan struct{}
+		// started guards readStarted.
+		started sync.Once
+		// mu guards the failure configuration below.
+		mu sync.Mutex
+		// failHash is the script hash whose EVALSHA calls fail.
+		failHash string
+		// failKey restricts injected failures to invocations naming this key.
+		failKey string
+	}
+)
+
+// errInjected is the transport failure injected by redisCommandHook.
+var errInjected = errors.New("injected redis failure")
+
+// newRedisCommandHook returns a hook with no active failure.
+func newRedisCommandHook() *redisCommandHook {
+	return &redisCommandHook{readStarted: make(chan struct{})}
+}
+
+// failScript makes EVALSHA calls of the script with the given hash fail when
+// their arguments include key.
+func (h *redisCommandHook) failScript(hash, key string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.failHash, h.failKey = hash, key
+}
+
+// clearFailure removes the active script failure.
+func (h *redisCommandHook) clearFailure() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.failHash, h.failKey = "", ""
+}
+
+// DialHook preserves the client's normal Redis connection behavior.
+func (h *redisCommandHook) DialHook(next redis.DialHook) redis.DialHook {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		return next(ctx, network, addr)
+	}
+}
+
+// ProcessHook blocks reads and injects script failures per the hook
+// configuration.
+func (h *redisCommandHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
+	return func(ctx context.Context, cmd redis.Cmder) error {
+		switch cmd.Name() {
+		case "xreadgroup":
+			if h.blockRead.Load() {
+				h.started.Do(func() { close(h.readStarted) })
+				<-ctx.Done()
+				return ctx.Err()
+			}
+		case "evalsha":
+			h.mu.Lock()
+			hash, key := h.failHash, h.failKey
+			h.mu.Unlock()
+			if hash != "" && len(cmd.Args()) > 1 && cmd.Args()[1] == hash {
+				for _, arg := range cmd.Args() {
+					if s, ok := arg.(string); ok && s == key {
+						return errInjected
+					}
+				}
+			}
+		}
+		return next(ctx, cmd)
+	}
+}
+
+// ProcessPipelineHook preserves pipeline behavior; the sink does not issue
+// pipelines on the paths exercised by these tests.
+func (h *redisCommandHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.ProcessPipelineHook {
+	return func(ctx context.Context, cmds []redis.Cmder) error {
+		return next(ctx, cmds)
+	}
+}

--- a/streaming/streams.go
+++ b/streaming/streams.go
@@ -8,7 +8,6 @@ import (
 
 	redis "github.com/redis/go-redis/v9"
 	"goa.design/pulse/pulse"
-	"goa.design/pulse/rmap"
 	"goa.design/pulse/streaming/options"
 )
 
@@ -180,41 +179,20 @@ func (s *Stream) Remove(ctx context.Context, ids ...string) error {
 	return nil
 }
 
-// Destroy deletes the entire stream and all its messages.
+// Destroy deletes the entire stream: its events and every piece of sink
+// metadata (consumer groups, recovery cursors, leases, and the sink
+// membership map) in one atomic operation. The stream lifecycle is marked
+// destroyed so concurrent sinks cannot resurrect the metadata; only a
+// subsequent NewSink or Sink.AddStream call deliberately recreates the
+// stream. Destroy is idempotent.
 func (s *Stream) Destroy(ctx context.Context) error {
-	if err := s.rdb.Del(ctx, s.key).Err(); err != nil {
+	if err := destroyStream(ctx, s); err != nil {
 		err := fmt.Errorf("failed to destroy stream: %w", err)
-		s.logger.Error(err)
-		return err
-	}
-	if err := s.destroyConsumersMap(ctx); err != nil {
-		err := fmt.Errorf("failed to destroy stream sink map: %w", err)
 		s.logger.Error(err)
 		return err
 	}
 	s.logger.Info("stream deleted")
 	return nil
-}
-
-// destroyConsumersMap removes the per-stream sink membership map through the
-// rmap destroy protocol so reconnecting replicas observe the same revisioned
-// destroy semantics as every other replicated map.
-func (s *Stream) destroyConsumersMap(ctx context.Context) error {
-	mapName := consumersMapName(s)
-	mapKey := fmt.Sprintf("map:%s:content", mapName)
-	exists, err := s.rdb.Exists(ctx, mapKey).Result()
-	if err != nil {
-		return err
-	}
-	if exists == 0 {
-		return nil
-	}
-	consumers, err := rmap.Join(ctx, mapName, s.rdb, consumersMapOptions(s, s.rootLogger)...)
-	if err != nil {
-		return err
-	}
-	defer consumers.Close()
-	return consumers.Destroy(ctx)
 }
 
 // redisKeyRegex is a regular expression that matches valid Redis keys.

--- a/testing/redis.go
+++ b/testing/redis.go
@@ -69,6 +69,11 @@ func CleanupRedis(t *testing.T, rdb *redis.Client, checkClean bool, testName str
 					// reconnecting replicas can order the next generation correctly.
 					continue
 				}
+				if isDestroyedStreamLifecycle(ctx, rdb, k) {
+					// Destroyed stream lifecycles are the intentional fence that
+					// prevents concurrent sinks from resurrecting stream metadata.
+					continue
+				}
 				if streamRegexp.MatchString(k) {
 					// Node streams are cleaned up asynchronously, so ignore them
 					continue
@@ -82,6 +87,17 @@ func CleanupRedis(t *testing.T, rdb *redis.Client, checkClean bool, testName str
 		require.NoError(t, keysErr)
 	}
 	assert.NoError(t, rdb.FlushDB(ctx).Err())
+}
+
+// isDestroyedStreamLifecycle reports whether key is the lifecycle fence of a
+// destroyed stream. Destroyed lifecycles intentionally outlive Stream.Destroy
+// so concurrent sinks cannot recreate the stream metadata.
+func isDestroyedStreamLifecycle(ctx context.Context, rdb *redis.Client, key string) bool {
+	if !strings.HasPrefix(key, "pulse:streammeta:") || !strings.HasSuffix(key, ":lifecycle") {
+		return false
+	}
+	state, err := rdb.HGet(ctx, key, "state").Result()
+	return err == nil && state == "destroyed"
 }
 
 func isDestroyTombstone(ctx context.Context, rdb *redis.Client, key string) bool {


### PR DESCRIPTION
## Summary

- Sinks recover from Redis consumer-group loss (e.g. `XGROUP DESTROY`, state flush) by atomically recreating the group at a durable per-stream recovery cursor derived from exact PEL state — never `$` — so no unacknowledged event is lost; previously `NOGROUP` was silently swallowed, permanently starving consumers.
- Reader and sink Redis failures retry with half-to-full jittered exponential backoff instead of synchronized deterministic intervals.
- `Sink.Close` cancels in-flight sink-owned Redis I/O; `AddStream`/`RemoveStream` reject use after close (`ErrSinkClosed`) and are failure-atomic; stream TTL is restored on the `BUSYGROUP` path.
- `XAUTOCLAIM` and stale-consumer cleanup run under an atomic Redis-time fenced lease so a stale owner cannot mutate the PEL after takeover.
- `Stream.Destroy` installs a lifecycle fence checked atomically by every stream-scoped metadata write, so concurrent sinks/keepalives cannot resurrect destroyed streams.
- A batch read for a stream removed concurrently from the sink is left pending for surviving group members instead of being acknowledged undelivered.

Fully source-compatible: exported option structs and all exported signatures are unchanged (locked by a compile-only external-package test); `pool/` source is untouched.

## Test plan

- [x] `go test -race ./streaming/... ./streaming/options/...` against live Redis (3 consecutive green runs)
- [x] `go test -race ./pool/...` with unchanged pool source (compat proof)
- [x] Forced `XGROUP DESTROY` recovery test: unacked events redelivered exactly once, acked events never redelivered
- [x] Destroy-fence, lease-fencing, close-cancellation, and removed-stream-pending regression tests
- [x] `go vet`, `gofmt` clean